### PR TITLE
Fix for resto tab showing wrong menu

### DIFF
--- a/app/src/main/java/be/ugent/zeus/hydra/fragments/resto/RestoFragment.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/fragments/resto/RestoFragment.java
@@ -146,12 +146,18 @@ public class RestoFragment extends LoaderFragment<RestoOverview> {
         if(DateTime.now().isAfter(DateTime.now().withHourOfDay(14))) {
             menu = data.get(1);
         }
-        if(m.findFragmentByTag(FRAGMENT_TAG) == null) {
-            MenuFragment fragment = MenuFragment.newInstance(menu);
-            FragmentTransaction fragmentTransaction = m.beginTransaction();
-            fragmentTransaction.add(R.id.menu_today_card_layout, fragment, FRAGMENT_TAG);
-            fragmentTransaction.commit();
+
+        //Delete old fragment if needed
+        if(m.findFragmentByTag(FRAGMENT_TAG) != null) {
+            m.beginTransaction().remove(m.findFragmentByTag(FRAGMENT_TAG)).commit();
         }
+
+        //Add new fragment
+        MenuFragment fragment = MenuFragment.newInstance(menu);
+        FragmentTransaction fragmentTransaction = m.beginTransaction();
+        fragmentTransaction.add(R.id.menu_today_card_layout, fragment, FRAGMENT_TAG);
+        fragmentTransaction.commit();
+
         title.setText(String.format(getString(R.string.resto_menu_title), DateUtils.getFriendlyDate(menu.getDate())));
     }
 

--- a/app/src/main/java/be/ugent/zeus/hydra/fragments/resto/RestoFragment.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/fragments/resto/RestoFragment.java
@@ -37,6 +37,9 @@ public class RestoFragment extends LoaderFragment<RestoOverview> {
 
     private static final String FRAGMENT_TAG = "menu_today_fragment";
 
+    //The hour after which every resto is closed are closed.
+    private static final int CLOSING_HOUR = 20;
+
     private TextView title;
     private Button viewMenu;
     private Button viewSandwich;
@@ -143,7 +146,7 @@ public class RestoFragment extends LoaderFragment<RestoOverview> {
         }
 
         RestoMenu menu = data.get(0);
-        if(DateTime.now().isAfter(DateTime.now().withHourOfDay(14))) {
+        if(DateTime.now().isAfter(DateTime.now().withHourOfDay(CLOSING_HOUR))) {
             menu = data.get(1);
         }
 

--- a/app/src/main/java/be/ugent/zeus/hydra/fragments/resto/RestoFragment.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/fragments/resto/RestoFragment.java
@@ -37,7 +37,7 @@ public class RestoFragment extends LoaderFragment<RestoOverview> {
 
     private static final String FRAGMENT_TAG = "menu_today_fragment";
 
-    //The hour after which every resto is closed are closed.
+    //The hour after which every resto is closed.
     private static final int CLOSING_HOUR = 20;
 
     private TextView title;


### PR DESCRIPTION
The old fragment was not always deleted, and showed an older menu instead.