### PR TITLE
Icons for info types.

### DIFF
--- a/app/src/main/java/be/ugent/zeus/hydra/activities/SchamperArticleActivity.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/activities/SchamperArticleActivity.java
@@ -14,7 +14,6 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.ImageView;
-import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import be.ugent.zeus.hydra.HydraApplication;
@@ -50,7 +49,6 @@ public class SchamperArticleActivity extends ToolbarActivity {
         TextView text = $(R.id.text);
         TextView intro = $(R.id.intro);
         TextView author = $(R.id.author);
-        LinearLayout wrapper = $(R.id.article_wrapper);
 
         RecyclerView imageGrid = $(R.id.image_grid);
         SchamperImageAdapter adapter = new SchamperImageAdapter();

--- a/app/src/main/java/be/ugent/zeus/hydra/fragments/InfoFragment.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/fragments/InfoFragment.java
@@ -8,6 +8,7 @@ import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+
 import be.ugent.zeus.hydra.R;
 import be.ugent.zeus.hydra.activities.InfoSubItemActivity;
 import be.ugent.zeus.hydra.fragments.common.LoaderFragment;
@@ -44,6 +45,7 @@ public class InfoFragment extends LoaderFragment<InfoList> {
         if (bundle != null) {
             InfoList infoItems = new InfoList();
             ArrayList<InfoItem> list = bundle.getParcelableArrayList(InfoSubItemActivity.INFO_ITEMS);
+            assert list != null;
             infoItems.addAll(list);
             receiveData(infoItems);
             this.autoStart = false;

--- a/app/src/main/java/be/ugent/zeus/hydra/models/info/InfoItem.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/models/info/InfoItem.java
@@ -8,9 +8,13 @@ import com.google.gson.annotations.SerializedName;
 import java.io.Serializable;
 
 /**
- * Created by Juta on 03/03/2016.
+ * An info item.
+ *
+ * @author Juta
+ * @author Niko Strijbol
  */
 public class InfoItem implements Parcelable, Serializable {
+
     private String title;
     private String image;
     private String html;
@@ -19,27 +23,6 @@ public class InfoItem implements Parcelable, Serializable {
     private String urlAndroid;
     @SerializedName("subcontent")
     private InfoList subContent;
-
-    protected InfoItem(Parcel in) {
-        title = in.readString();
-        image = in.readString();
-        html = in.readString();
-        url = in.readString();
-        urlAndroid = in.readString();
-        in.readList(subContent, null);
-    }
-
-    public static final Creator<InfoItem> CREATOR = new Creator<InfoItem>() {
-        @Override
-        public InfoItem createFromParcel(Parcel in) {
-            return new InfoItem(in);
-        }
-
-        @Override
-        public InfoItem[] newArray(int size) {
-            return new InfoItem[size];
-        }
-    };
 
     public String getTitle() {
         return title;
@@ -88,6 +71,42 @@ public class InfoItem implements Parcelable, Serializable {
     public void setSubContent(InfoList subContent) {
         this.subContent = subContent;
     }
+
+    /**
+     * @return The type of this info item.
+     */
+    public InfoType getType() {
+        if (getUrlAndroid() != null) {
+            return InfoType.EXTERNAL_APP;
+        } else if (getHtml() != null) {
+            return InfoType.INTERNAL;
+        } else if (getSubContent() != null) {
+            return InfoType.SUBLIST;
+        } else {
+            return InfoType.EXTERNAL_LINK;
+        }
+    }
+
+    protected InfoItem(Parcel in) {
+        title = in.readString();
+        image = in.readString();
+        html = in.readString();
+        url = in.readString();
+        urlAndroid = in.readString();
+        in.readList(subContent, null);
+    }
+
+    public static final Creator<InfoItem> CREATOR = new Creator<InfoItem>() {
+        @Override
+        public InfoItem createFromParcel(Parcel in) {
+            return new InfoItem(in);
+        }
+
+        @Override
+        public InfoItem[] newArray(int size) {
+            return new InfoItem[size];
+        }
+    };
 
     @Override
     public int describeContents() {

--- a/app/src/main/java/be/ugent/zeus/hydra/models/info/InfoType.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/models/info/InfoType.java
@@ -1,0 +1,121 @@
+package be.ugent.zeus.hydra.models.info;
+
+import android.content.ActivityNotFoundException;
+import android.content.Context;
+import android.content.Intent;
+import android.graphics.drawable.Drawable;
+import android.net.Uri;
+import android.support.annotation.ColorRes;
+import android.support.annotation.DrawableRes;
+import android.support.annotation.Nullable;
+
+import be.ugent.zeus.hydra.R;
+import be.ugent.zeus.hydra.activities.InfoSubItemActivity;
+import be.ugent.zeus.hydra.activities.WebViewActivity;
+import be.ugent.zeus.hydra.utils.ViewUtils;
+
+/**
+ * The type of information (external url/app, internal url, ...).
+ *
+ * The different behavior warrants a real enum because if-else/switch is bad.
+ *
+ * @author Niko Strijbol
+ */
+public enum InfoType {
+
+    //Opens in the browser
+    EXTERNAL_LINK(R.drawable.ic_open_in_browser_24dp) {
+        @Override
+        public void doOnClick(Context context, InfoItem infoItem) {
+            context.startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(infoItem.getUrl())));
+        }
+    },
+
+    //Opens in another app
+    EXTERNAL_APP(R.drawable.ic_open_in_new_24dp) {
+
+        private static final String PLAY_STORE = "market://details?id=";
+        private static final String PLAY_URL = "https://play.google.com/store/apps/details?id=";
+
+        @Override
+        public void doOnClick(Context context, InfoItem infoItem) {
+
+            String androidUrl = infoItem.getUrlAndroid();
+
+            try {
+                context.startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(PLAY_STORE + androidUrl)));
+            } catch (ActivityNotFoundException e) {
+                context.startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(PLAY_URL + androidUrl)));
+            }
+        }
+    },
+
+    //Opens in the app itself (web view or native)
+    INTERNAL {
+
+        private final static String HTML_API = "https://zeus.ugent.be/hydra/api/2.0/info/";
+
+        @Override
+        public void doOnClick(Context context, InfoItem infoItem) {
+            Intent intent = new Intent(context, WebViewActivity.class);
+            intent.putExtra(WebViewActivity.URL, HTML_API + infoItem.getHtml());
+            intent.putExtra(WebViewActivity.TITLE, infoItem.getTitle());
+            context.startActivity(intent);
+        }
+    },
+
+    //Opens a new list of info items.
+    SUBLIST(R.drawable.ic_chevron_right_24dp) {
+        @Override
+        public void doOnClick(Context context, InfoItem infoItem) {
+            Intent intent = new Intent(context, InfoSubItemActivity.class);
+            intent.putParcelableArrayListExtra(InfoSubItemActivity.INFO_ITEMS, infoItem.getSubContent());
+            intent.putExtra(InfoSubItemActivity.INFO_TITLE, infoItem.getTitle());
+            context.startActivity(intent);
+        }
+    };
+
+    private final int drawable;
+    private static final int NO_DRAWABLE = 0;
+
+    /**
+     * @param drawable The ID of the vector drawable.
+     */
+    InfoType(@DrawableRes int drawable) {
+        this.drawable = drawable;
+    }
+
+    /**
+     * No drawable.
+     */
+    InfoType() {
+        this(NO_DRAWABLE);
+    }
+
+    /**
+     * Get the drawable for this category.
+     *
+     * @param context The context.
+     * @param color The color to tint the drawable in.
+     *
+     * @return The drawable or null if there is no drawable.
+     */
+    @Nullable
+    public Drawable getDrawable(Context context, @ColorRes int color) {
+
+        //If there is no drawable, return null.
+        if(drawable == NO_DRAWABLE) {
+            return null;
+        }
+
+        return ViewUtils.getTintedVectorDrawable(context, this.drawable, color);
+    }
+
+    /**
+     * The intent to be started for this type.
+     *
+     * @param context The context to launch the intent.
+     * @param infoItem The item.
+     */
+    public abstract void doOnClick(Context context, InfoItem infoItem);
+}

--- a/app/src/main/java/be/ugent/zeus/hydra/recyclerview/viewholder/InfoViewHolder.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/recyclerview/viewholder/InfoViewHolder.java
@@ -1,33 +1,22 @@
 package be.ugent.zeus.hydra.recyclerview.viewholder;
 
-import java.util.List;
-
-import android.content.ComponentName;
 import android.content.Context;
-import android.content.Intent;
-import android.content.pm.ActivityInfo;
-import android.content.pm.ResolveInfo;
 import android.graphics.drawable.Drawable;
-import android.net.Uri;
-
 import android.view.View;
 import android.widget.TextView;
 
 import be.ugent.zeus.hydra.R;
-import be.ugent.zeus.hydra.activities.InfoSubItemActivity;
-import be.ugent.zeus.hydra.activities.WebViewActivity;
 import be.ugent.zeus.hydra.models.info.InfoItem;
-import be.ugent.zeus.hydra.models.info.InfoList;
 import be.ugent.zeus.hydra.utils.ViewUtils;
 
 import static be.ugent.zeus.hydra.utils.ViewUtils.$;
 
 /**
+ * View holder for info items.
+ *
  * @author Niko Strijbol
  */
 public class InfoViewHolder extends AbstractViewHolder<InfoItem> {
-
-    private final static String HTML_API = "https://zeus.ugent.be/hydra/api/2.0/info/";
 
     private TextView title;
 
@@ -38,76 +27,27 @@ public class InfoViewHolder extends AbstractViewHolder<InfoItem> {
 
     @Override
     public void populate(final InfoItem infoItem) {
-        title.setText(infoItem.getTitle());
-        //// TODO: 06/04/2016 set correct linkview
 
-        final String androidUrl = infoItem.getUrlAndroid();
-        final String url = infoItem.getUrl();
-        final String html = infoItem.getHtml();
-        final InfoList infolist = infoItem.getSubContent();
+        title.setText(infoItem.getTitle());
 
         itemView.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                if (androidUrl != null) {
-                    Intent rateIntent = new Intent(Intent.ACTION_VIEW, Uri.parse("market://details?id=" + androidUrl));
-                    boolean marketFound = false;
-
-                    // find all applications able to handle our rateIntent
-                    final List<ResolveInfo> otherApps = itemView.getContext().getPackageManager().queryIntentActivities(rateIntent, 0);
-                    for (ResolveInfo otherApp : otherApps) {
-                        // look for Google Play application
-                        if (otherApp.activityInfo.applicationInfo.packageName.equals("com.android.vending")) {
-
-                            ActivityInfo otherAppActivity = otherApp.activityInfo;
-                            ComponentName componentName = new ComponentName(
-                                    otherAppActivity.applicationInfo.packageName,
-                                    otherAppActivity.name
-                            );
-                            rateIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED);
-                            rateIntent.setComponent(componentName);
-                            itemView.getContext().startActivity(rateIntent);
-                            marketFound = true;
-                            break;
-                        }
-                    }
-
-                    // if GP not present on device, open web browser
-                    if (!marketFound) {
-                        Intent webIntent = new Intent(Intent.ACTION_VIEW, Uri.parse("https://play.google.com/store/apps/details?id=" + androidUrl));
-                        itemView.getContext().startActivity(webIntent);
-                    }
-                } else if (url != null) {
-                    Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
-                    itemView.getContext().startActivity(browserIntent);
-                } else if (html != null) {
-                    Intent intent = new Intent(v.getContext(), WebViewActivity.class);
-                    intent.putExtra(WebViewActivity.URL, HTML_API + html);
-                    intent.putExtra(WebViewActivity.TITLE, infoItem.getTitle());
-                    itemView.getContext().startActivity(intent);
-                } else if (infolist != null) {
-                    Intent intent = new Intent(v.getContext(), InfoSubItemActivity.class);
-                    intent.putParcelableArrayListExtra(InfoSubItemActivity.INFO_ITEMS, infolist);
-                    intent.putExtra(InfoSubItemActivity.INFO_TITLE, infoItem.getTitle());
-                    itemView.getContext().startActivity(intent);
-                }
+                infoItem.getType().doOnClick(v.getContext(), infoItem);
             }
         });
 
+        int color = R.color.ugent_blue_dark;
+        Context c = itemView.getContext();
+        Drawable more = infoItem.getType().getDrawable(c, color);
+
+        //If the item itself has an image.
         if (infoItem.getImage() != null) {
-            Context c = itemView.getContext();
             int resId = c.getResources().getIdentifier("ic_" + infoItem.getImage(), "drawable", itemView.getContext().getPackageName());
-            int color = R.color.ugent_blue_dark;
-
             Drawable icon = ViewUtils.getTintedVectorDrawable(c, resId, color);
-            Drawable more = ViewUtils.getTintedVectorDrawable(c, R.drawable.ic_chevron_right_24dp, color);
-
-            //Remove arrow if internal link
-            if(androidUrl == null && url == null && html != null) {
-                title.setCompoundDrawablesWithIntrinsicBounds(icon, null, null, null);
-            } else {
-                title.setCompoundDrawablesWithIntrinsicBounds(icon, null, more, null);
-            }
+            title.setCompoundDrawablesWithIntrinsicBounds(icon, null, more, null);
+        } else {
+            title.setCompoundDrawablesWithIntrinsicBounds(null, null, more, null);
         }
     }
 }

--- a/app/src/main/res/drawable/ic_open_in_browser_24dp.xml
+++ b/app/src/main/res/drawable/ic_open_in_browser_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M19,4L5,4c-1.11,0 -2,0.9 -2,2v12c0,1.1 0.89,2 2,2h4v-2L5,18L5,8h14v10h-4v2h4c1.1,0 2,-0.9 2,-2L21,6c0,-1.1 -0.89,-2 -2,-2zM12,10l-4,4h3v6h2v-6h3l-4,-4z"/>
+</vector>

--- a/app/src/main/res/layout/activity_info_sub_item.xml
+++ b/app/src/main/res/layout/activity_info_sub_item.xml
@@ -15,13 +15,10 @@
 
     </android.support.design.widget.AppBarLayout>
 
-    <LinearLayout
+    <FrameLayout
         android:id="@+id/info_sub_item"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:orientation="vertical"
-        app:layout_behavior="@string/appbar_scrolling_view_behavior">
-
-    </LinearLayout>
+        app:layout_behavior="@string/appbar_scrolling_view_behavior" />
 
 </android.support.design.widget.CoordinatorLayout>

--- a/app/src/main/res/menu/menu_event.xml
+++ b/app/src/main/res/menu/menu_event.xml
@@ -11,6 +11,6 @@
 		android:id="@+id/event_link"
 		android:orderInCategory="100"
 		app:showAsAction="ifRoom"
-        android:icon="@drawable/ic_open_in_new_24dp"
+        android:icon="@drawable/ic_open_in_browser_24dp"
 		android:title="Open link" />
 </menu>

--- a/app/src/main/res/menu/menu_schamper.xml
+++ b/app/src/main/res/menu/menu_schamper.xml
@@ -6,7 +6,7 @@
         android:id="@+id/schamper_browser"
         android:orderInCategory="50"
         app:showAsAction="ifRoom"
-        android:icon="@drawable/ic_open_in_new_24dp"
+        android:icon="@drawable/ic_open_in_browser_24dp"
         android:title="Openen in browser" />
 
     <item


### PR DESCRIPTION
Fixes #67.

Every type of info card now shows the correct icon. Cards that open in an internal webview intentionally have no icon, since they open in the same app. The icons are official Material Design icons.

Screenshot:
![device-2016-08-05-233901](https://cloud.githubusercontent.com/assets/1756811/17451280/e47a6150-5b65-11e6-8082-c0e6ddde7c58.png)
