### PR TITLE
Properly support refresh tokens

### DIFF
--- a/app/src/main/java/be/ugent/zeus/hydra/minerva/database/DatabaseHelper.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/minerva/database/DatabaseHelper.java
@@ -33,7 +33,8 @@ public class DatabaseHelper extends SQLiteOpenHelper {
     }
 
     private DatabaseHelper(Context context) {
-        super(context, NAME, new DebugCursorFactory(true), VERSION);
+        //super(context, NAME, new DebugCursorFactory(true), VERSION);
+        super(context, NAME, null, VERSION);
     }
 
     @Override

--- a/app/src/main/java/be/ugent/zeus/hydra/minerva/sync/SyncNotificationBuilder.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/minerva/sync/SyncNotificationBuilder.java
@@ -1,7 +1,9 @@
 package be.ugent.zeus.hydra.minerva.sync;
 
 import android.app.NotificationManager;
+import android.app.PendingIntent;
 import android.content.Context;
+import android.content.Intent;
 import android.support.v7.app.NotificationCompat;
 
 import be.ugent.zeus.hydra.R;
@@ -17,20 +19,44 @@ public class SyncNotificationBuilder {
     private static final int NOTIFICATION_ID = 600;
 
 
-    public static void showError(Context context) {
+    /**
+     * Show a notification prompting the user to renew their credentials.
+     *
+     * @param context A context.
+     * @param intent The intent to launch a new activity.
+     */
+    public static void showError(Context context, Intent intent) {
+
+        PendingIntent pendingIntent = PendingIntent.getActivity(context, 0, intent, 0);
 
         NotificationCompat.Builder builder = new NotificationCompat.Builder(context);
         builder.setSmallIcon(R.drawable.ic_error_24dp)
+                .setAutoCancel(true)
                 .setCategory(CATEGORY_ERROR)
-        .setContentTitle("Minerva-fout")
-        .setContentText("Synchronisatiefout")
-        .setStyle(new android.support.v4.app.NotificationCompat.BigTextStyle()
-                .bigText("Er trad een fout op bij het synchroniseren met Minerva. Gegevens kunnen verouderd zijn.")
-        );
+                .setContentTitle("Minerva-fout")
+                .setContentText("Druk om opnieuw aanmelden vereist")
+                .setContentIntent(pendingIntent)
+                .setStyle(new android.support.v4.app.NotificationCompat.BigTextStyle()
+                        .bigText("De inloggegevens zijn verouderd en opnieuw aanmelden is vereist voor uw Minerva-account.")
+                );
 
         NotificationManager manager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
         manager.notify(NOTIFICATION_ID, builder.build());
 
+    }
+
+    public static void showError(Context context) {
+        NotificationCompat.Builder builder = new NotificationCompat.Builder(context);
+        builder.setSmallIcon(R.drawable.ic_error_24dp)
+                .setCategory(CATEGORY_ERROR)
+                .setContentTitle("Minerva-fout")
+                .setContentText("Synchronisatiefout")
+                .setStyle(new android.support.v4.app.NotificationCompat.BigTextStyle()
+                        .bigText("Er trad een fout op bij het synchroniseren met Minerva. Gegevens kunnen verouderd zijn.")
+                );
+
+        NotificationManager manager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+        manager.notify(NOTIFICATION_ID, builder.build());
     }
 
 }

--- a/app/src/main/java/be/ugent/zeus/hydra/minerva/sync/SyncNotificationBuilder.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/minerva/sync/SyncNotificationBuilder.java
@@ -33,11 +33,11 @@ public class SyncNotificationBuilder {
         builder.setSmallIcon(R.drawable.ic_error_24dp)
                 .setAutoCancel(true)
                 .setCategory(CATEGORY_ERROR)
-                .setContentTitle("Minerva-fout")
-                .setContentText("Druk om opnieuw aanmelden vereist")
+                .setContentTitle("Minerva: opnieuw aanndelden")
+                .setContentText("Druk om opnieuw aan te melden")
                 .setContentIntent(pendingIntent)
                 .setStyle(new android.support.v4.app.NotificationCompat.BigTextStyle()
-                        .bigText("De inloggegevens zijn verouderd en opnieuw aanmelden is vereist voor uw Minerva-account.")
+                        .bigText("Je moet opnieuw aanmelden bij Minerva, want de inloggegevens zijn verouderd.")
                 );
 
         NotificationManager manager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);

--- a/app/src/main/java/be/ugent/zeus/hydra/requests/common/AbstractRequest.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/requests/common/AbstractRequest.java
@@ -28,20 +28,20 @@ public abstract class AbstractRequest<T> implements Request<T> {
     @NonNull
     @Override
     public T performRequest() throws RequestFailureException {
-        RestTemplate restTemplate = createRestTemplate();
-        ResponseEntity<T> result;
-
         try {
+            RestTemplate restTemplate = createRestTemplate();
+            ResponseEntity<T> result;
+
             if (getURLVariables() == null) {
                 result = restTemplate.getForEntity(getAPIUrl(), getResultType());
             } else {
                 result = restTemplate.getForEntity(getAPIUrl(), getResultType(), getURLVariables());
             }
-        } catch (RestClientException e) {
+
+            return result.getBody();
+        } catch (RestClientException | RestTemplateException e) {
             throw new RequestFailureException(e);
         }
-
-        return result.getBody();
     }
 
     @NonNull
@@ -59,7 +59,7 @@ public abstract class AbstractRequest<T> implements Request<T> {
     /**
      * @return The rest template used by Spring to perform the request.
      */
-    protected RestTemplate createRestTemplate() {
+    protected RestTemplate createRestTemplate() throws RestTemplateException {
         RestTemplate restTemplate = new RestTemplate();
         restTemplate.getMessageConverters().add(new GsonHttpMessageConverter());
         return restTemplate;

--- a/app/src/main/java/be/ugent/zeus/hydra/requests/common/RestTemplateException.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/requests/common/RestTemplateException.java
@@ -1,0 +1,17 @@
+package be.ugent.zeus.hydra.requests.common;
+
+/**
+ * Exception thrown when the rest template could not be made.
+ *
+ * @author Niko Strijbol
+ */
+public class RestTemplateException extends Exception {
+
+    public RestTemplateException() {
+        super();
+    }
+
+    public RestTemplateException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/app/src/main/java/be/ugent/zeus/hydra/requests/common/TokenException.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/requests/common/TokenException.java
@@ -1,0 +1,17 @@
+package be.ugent.zeus.hydra.requests.common;
+
+/**
+ * Exception thrown when something went wrong while getting a token.
+ *
+ * @author Niko Strijbol
+ */
+public class TokenException extends Exception {
+
+    public TokenException() {
+        super();
+    }
+
+    public TokenException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/app/src/main/java/be/ugent/zeus/hydra/requests/common/TokenRequest.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/requests/common/TokenRequest.java
@@ -22,15 +22,19 @@ public abstract class TokenRequest<T> extends AbstractRequest<T> {
      *
      * @return The token.
      */
-    protected abstract String getToken();
+    protected abstract String getToken() throws TokenException;
 
     /**
      * Set the API interceptor.
      */
     @Override
-    protected RestTemplate createRestTemplate() {
-        RestTemplate t = super.createRestTemplate();
-        t.setInterceptors(Collections.<ClientHttpRequestInterceptor>singletonList(new TokenRequestInterceptor(getToken())));
-        return t;
+    protected RestTemplate createRestTemplate() throws RestTemplateException {
+        try {
+            RestTemplate t = super.createRestTemplate();
+            t.setInterceptors(Collections.<ClientHttpRequestInterceptor>singletonList(new TokenRequestInterceptor(getToken())));
+            return t;
+        } catch (TokenException e) {
+            throw new RestTemplateException(e);
+        }
     }
 }


### PR DESCRIPTION
Apparently the refresh tokens from Minerva expire pretty quickly.

When this happens, a special notification is issued informing the user of this, and clicking that notification will allow the user to re-authorise Minerva (and thus get new refresh tokens).

Previously, a generic error was shown, and the user had no clue as to why the synchronisation was failing.