### PR TITLE
Upgrade Minerva to production

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -213,7 +213,7 @@
         </service>
 
         <!-- Account service -->
-        <service android:name=".auth.MinervaService">
+        <service android:name=".minerva.auth.MinervaService">
             <intent-filter>
                 <action android:name="android.accounts.AccountAuthenticator" />
             </intent-filter>

--- a/app/src/main/java/be/ugent/zeus/hydra/activities/minerva/AuthActivity.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/activities/minerva/AuthActivity.java
@@ -11,11 +11,11 @@ import android.widget.TextView;
 
 import be.ugent.zeus.hydra.R;
 import be.ugent.zeus.hydra.activities.common.ToolbarAccountAuthenticatorActivity;
-import be.ugent.zeus.hydra.auth.AccountUtils;
-import be.ugent.zeus.hydra.auth.MinervaAuthenticator;
-import be.ugent.zeus.hydra.auth.MinervaConfig;
-import be.ugent.zeus.hydra.auth.models.BearerToken;
-import be.ugent.zeus.hydra.auth.models.GrantInformation;
+import be.ugent.zeus.hydra.minerva.auth.AccountUtils;
+import be.ugent.zeus.hydra.minerva.auth.MinervaAuthenticator;
+import be.ugent.zeus.hydra.minerva.auth.MinervaConfig;
+import be.ugent.zeus.hydra.minerva.auth.models.BearerToken;
+import be.ugent.zeus.hydra.minerva.auth.models.GrantInformation;
 import be.ugent.zeus.hydra.requests.common.Request;
 import be.ugent.zeus.hydra.requests.common.RequestFailureException;
 import be.ugent.zeus.hydra.requests.minerva.UserInfoRequest;

--- a/app/src/main/java/be/ugent/zeus/hydra/fragments/home/HomeFragment.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/fragments/home/HomeFragment.java
@@ -15,7 +15,7 @@ import android.view.ViewGroup;
 import android.widget.ProgressBar;
 
 import be.ugent.zeus.hydra.R;
-import be.ugent.zeus.hydra.auth.AccountUtils;
+import be.ugent.zeus.hydra.minerva.auth.AccountUtils;
 import be.ugent.zeus.hydra.recyclerview.adapters.HomeCardAdapter;
 
 import static be.ugent.zeus.hydra.utils.ViewUtils.$;

--- a/app/src/main/java/be/ugent/zeus/hydra/fragments/minerva/MinervaFragment.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/fragments/minerva/MinervaFragment.java
@@ -18,8 +18,8 @@ import android.widget.Button;
 import android.widget.Toast;
 
 import be.ugent.zeus.hydra.R;
-import be.ugent.zeus.hydra.auth.AccountUtils;
-import be.ugent.zeus.hydra.auth.MinervaConfig;
+import be.ugent.zeus.hydra.minerva.auth.AccountUtils;
+import be.ugent.zeus.hydra.minerva.auth.MinervaConfig;
 import be.ugent.zeus.hydra.fragments.common.LoaderFragment;
 import be.ugent.zeus.hydra.loader.ThrowableEither;
 import be.ugent.zeus.hydra.minerva.announcement.AnnouncementDao;

--- a/app/src/main/java/be/ugent/zeus/hydra/fragments/preferences/MinervaFragment.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/fragments/preferences/MinervaFragment.java
@@ -9,7 +9,7 @@ import android.preference.PreferenceManager;
 
 import be.ugent.zeus.hydra.HydraApplication;
 import be.ugent.zeus.hydra.R;
-import be.ugent.zeus.hydra.auth.AccountUtils;
+import be.ugent.zeus.hydra.minerva.auth.AccountUtils;
 import be.ugent.zeus.hydra.minerva.sync.SyncUtils;
 
 /**

--- a/app/src/main/java/be/ugent/zeus/hydra/minerva/auth/AccountUtils.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/minerva/auth/AccountUtils.java
@@ -1,4 +1,4 @@
-package be.ugent.zeus.hydra.auth;
+package be.ugent.zeus.hydra.minerva.auth;
 
 import android.accounts.Account;
 import android.accounts.AccountManager;
@@ -9,9 +9,9 @@ import android.os.Bundle;
 import android.util.Log;
 
 import be.ugent.zeus.hydra.BuildConfig;
-import be.ugent.zeus.hydra.auth.models.BearerToken;
-import be.ugent.zeus.hydra.auth.requests.NewAccessTokenRequest;
-import be.ugent.zeus.hydra.auth.requests.RefreshAccessTokenRequest;
+import be.ugent.zeus.hydra.minerva.auth.models.BearerToken;
+import be.ugent.zeus.hydra.minerva.auth.requests.NewAccessTokenRequest;
+import be.ugent.zeus.hydra.minerva.auth.requests.RefreshAccessTokenRequest;
 import be.ugent.zeus.hydra.requests.common.Request;
 import org.apache.oltu.oauth2.client.request.OAuthClientRequest;
 import org.apache.oltu.oauth2.common.exception.OAuthSystemException;
@@ -20,7 +20,7 @@ import org.joda.time.DateTime;
 
 import java.io.IOException;
 
-import static be.ugent.zeus.hydra.auth.MinervaAuthenticator.EXP_DATE;
+import static be.ugent.zeus.hydra.minerva.auth.MinervaAuthenticator.EXP_DATE;
 
 /**
  * Helper class for working with a Minerva account.

--- a/app/src/main/java/be/ugent/zeus/hydra/minerva/auth/MinervaAuthenticator.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/minerva/auth/MinervaAuthenticator.java
@@ -1,4 +1,4 @@
-package be.ugent.zeus.hydra.auth;
+package be.ugent.zeus.hydra.minerva.auth;
 
 import android.accounts.*;
 import android.content.Context;
@@ -7,7 +7,7 @@ import android.os.Bundle;
 import android.text.TextUtils;
 import android.util.Log;
 
-import be.ugent.zeus.hydra.auth.models.BearerToken;
+import be.ugent.zeus.hydra.minerva.auth.models.BearerToken;
 import be.ugent.zeus.hydra.activities.minerva.AuthActivity;
 import be.ugent.zeus.hydra.requests.common.RequestFailureException;
 import be.ugent.zeus.hydra.requests.common.Request;

--- a/app/src/main/java/be/ugent/zeus/hydra/minerva/auth/MinervaConfig.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/minerva/auth/MinervaConfig.java
@@ -18,10 +18,12 @@
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package be.ugent.zeus.hydra.auth;
+package be.ugent.zeus.hydra.minerva.auth;
 
 /**
  * Various constants for Minerva accounts.
+ *
+ * The API endpoint is saved in the {@link be.ugent.zeus.hydra.requests.minerva.MinervaRequest} for now.
  *
  * @author Niko Strijbol
  * @author kevin
@@ -29,9 +31,9 @@ package be.ugent.zeus.hydra.auth;
 public class MinervaConfig {
 
     //Endpoints
-    public final static String AUTHORIZATION_ENDPOINT = "https://oauthq.ugent.be/authorize";
-    public final static String TOKEN_ENDPOINT = "https://oauthq.ugent.be/access_token";
-    public final static String GRANT_INFORMATION_ENDPOINT = "https://oauthq.ugent.be/tokeninfo";
+    public final static String AUTHORIZATION_ENDPOINT = "https://oauth.ugent.be/authorize";
+    public final static String TOKEN_ENDPOINT = "https://oauth.ugent.be/access_token";
+    public final static String GRANT_INFORMATION_ENDPOINT = "https://oauth.ugent.be/tokeninfo";
 
     //The URL scheme of the callback
     public final static String CALLBACK_SCHEME = "hydra-ugent";

--- a/app/src/main/java/be/ugent/zeus/hydra/minerva/auth/MinervaService.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/minerva/auth/MinervaService.java
@@ -1,4 +1,4 @@
-package be.ugent.zeus.hydra.auth;
+package be.ugent.zeus.hydra.minerva.auth;
 
 import android.app.Service;
 import android.content.Intent;

--- a/app/src/main/java/be/ugent/zeus/hydra/minerva/auth/OAuthConfiguration.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/minerva/auth/OAuthConfiguration.java
@@ -18,7 +18,7 @@
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package be.ugent.zeus.hydra.auth;
+package be.ugent.zeus.hydra.minerva.auth;
 
 /**
  * Wrapper class for the OAuth configuration.

--- a/app/src/main/java/be/ugent/zeus/hydra/minerva/auth/models/BearerToken.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/minerva/auth/models/BearerToken.java
@@ -18,32 +18,44 @@
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package be.ugent.zeus.hydra.auth.models;
+package be.ugent.zeus.hydra.minerva.auth.models;
 
 import com.google.gson.annotations.SerializedName;
 
-import java.io.Serializable;
-import java.util.Collection;
-
 /**
- * Information about the authorisation grant.
+ * A bearer token. This contains the various tokens and meta data about the tokens the Minerva API returns.
  *
  * @author Niko Strijbol
  * @author UGent
  */
 @SuppressWarnings("unused")
-public class GrantInformation implements Serializable {
+public class BearerToken {
 
-    private Collection<String> scopes;
+    @SerializedName("access_token")
+    private String accessToken;
 
-    @SerializedName("user")
-    private UserAttributes userAttributes;
+    @SerializedName("refresh_token")
+    private String refreshToken;
 
-    public Collection<String> getScopes() {
-        return scopes;
+    @SerializedName("token_type")
+    private String tokenType;
+
+    @SerializedName("expires_in")
+    private Integer expiresIn;
+
+    public String getAccessToken() {
+        return accessToken;
     }
 
-    public UserAttributes getUserAttributes() {
-        return userAttributes;
+    public String getRefreshToken() {
+        return refreshToken;
+    }
+
+    public String getTokenType() {
+        return tokenType;
+    }
+
+    public Integer getExpiresIn() {
+        return expiresIn;
     }
 }

--- a/app/src/main/java/be/ugent/zeus/hydra/minerva/auth/models/GrantInformation.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/minerva/auth/models/GrantInformation.java
@@ -18,59 +18,32 @@
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package be.ugent.zeus.hydra.auth.models;
+package be.ugent.zeus.hydra.minerva.auth.models;
 
 import com.google.gson.annotations.SerializedName;
 
 import java.io.Serializable;
-import java.util.ArrayList;
+import java.util.Collection;
 
 /**
- * Minerva user attributes.
+ * Information about the authorisation grant.
  *
  * @author Niko Strijbol
  * @author UGent
  */
 @SuppressWarnings("unused")
-public class UserAttributes implements Serializable {
+public class GrantInformation implements Serializable {
 
-    @SerializedName("mail")
-    private ArrayList<String> email;
+    private Collection<String> scopes;
 
-    @SuppressWarnings("SpellCheckingInspection")
-    @SerializedName("jobcategory")
-    private ArrayList<String> jobCategory;
+    @SerializedName("user")
+    private UserAttributes userAttributes;
 
-    @SuppressWarnings("SpellCheckingInspection")
-    @SerializedName("givenname")
-    private ArrayList<String> givenName;
-
-    @SerializedName("surname")
-    private ArrayList<String> surName;
-
-    private ArrayList<String> uid;
-
-    public String getFullName() {
-        return givenName + " " + surName;
+    public Collection<String> getScopes() {
+        return scopes;
     }
 
-    public ArrayList<String> getEmail() {
-        return email;
-    }
-
-    public ArrayList<String> getJobCategory() {
-        return jobCategory;
-    }
-
-    public ArrayList<String> getGivenName() {
-        return givenName;
-    }
-
-    public ArrayList<String> getSurName() {
-        return surName;
-    }
-
-    public ArrayList<String> getUid() {
-        return uid;
+    public UserAttributes getUserAttributes() {
+        return userAttributes;
     }
 }

--- a/app/src/main/java/be/ugent/zeus/hydra/minerva/auth/models/UserAttributes.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/minerva/auth/models/UserAttributes.java
@@ -18,44 +18,59 @@
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package be.ugent.zeus.hydra.auth.models;
+package be.ugent.zeus.hydra.minerva.auth.models;
 
 import com.google.gson.annotations.SerializedName;
 
+import java.io.Serializable;
+import java.util.ArrayList;
+
 /**
- * A bearer token. This contains the various tokens and meta data about the tokens the Minerva API returns.
+ * Minerva user attributes.
  *
  * @author Niko Strijbol
  * @author UGent
  */
 @SuppressWarnings("unused")
-public class BearerToken {
+public class UserAttributes implements Serializable {
 
-    @SerializedName("access_token")
-    private String accessToken;
+    @SerializedName("mail")
+    private ArrayList<String> email;
 
-    @SerializedName("refresh_token")
-    private String refreshToken;
+    @SuppressWarnings("SpellCheckingInspection")
+    @SerializedName("jobcategory")
+    private ArrayList<String> jobCategory;
 
-    @SerializedName("token_type")
-    private String tokenType;
+    @SuppressWarnings("SpellCheckingInspection")
+    @SerializedName("givenname")
+    private ArrayList<String> givenName;
 
-    @SerializedName("expires_in")
-    private Integer expiresIn;
+    @SerializedName("surname")
+    private ArrayList<String> surName;
 
-    public String getAccessToken() {
-        return accessToken;
+    private ArrayList<String> uid;
+
+    public String getFullName() {
+        return givenName + " " + surName;
     }
 
-    public String getRefreshToken() {
-        return refreshToken;
+    public ArrayList<String> getEmail() {
+        return email;
     }
 
-    public String getTokenType() {
-        return tokenType;
+    public ArrayList<String> getJobCategory() {
+        return jobCategory;
     }
 
-    public Integer getExpiresIn() {
-        return expiresIn;
+    public ArrayList<String> getGivenName() {
+        return givenName;
+    }
+
+    public ArrayList<String> getSurName() {
+        return surName;
+    }
+
+    public ArrayList<String> getUid() {
+        return uid;
     }
 }

--- a/app/src/main/java/be/ugent/zeus/hydra/minerva/auth/requests/AccessTokenRequest.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/minerva/auth/requests/AccessTokenRequest.java
@@ -1,9 +1,9 @@
-package be.ugent.zeus.hydra.auth.requests;
+package be.ugent.zeus.hydra.minerva.auth.requests;
 
 import android.support.annotation.NonNull;
 
-import be.ugent.zeus.hydra.auth.OAuthConfiguration;
-import be.ugent.zeus.hydra.auth.models.BearerToken;
+import be.ugent.zeus.hydra.minerva.auth.OAuthConfiguration;
+import be.ugent.zeus.hydra.minerva.auth.models.BearerToken;
 import be.ugent.zeus.hydra.requests.common.RequestFailureException;
 import be.ugent.zeus.hydra.requests.common.Request;
 import com.google.gson.Gson;

--- a/app/src/main/java/be/ugent/zeus/hydra/minerva/auth/requests/NewAccessTokenRequest.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/minerva/auth/requests/NewAccessTokenRequest.java
@@ -1,9 +1,9 @@
-package be.ugent.zeus.hydra.auth.requests;
+package be.ugent.zeus.hydra.minerva.auth.requests;
 
 import android.util.Log;
 
-import be.ugent.zeus.hydra.auth.MinervaConfig;
-import be.ugent.zeus.hydra.auth.OAuthConfiguration;
+import be.ugent.zeus.hydra.minerva.auth.MinervaConfig;
+import be.ugent.zeus.hydra.minerva.auth.OAuthConfiguration;
 import org.apache.oltu.oauth2.client.OAuthClient;
 import org.apache.oltu.oauth2.client.URLConnectionClient;
 import org.apache.oltu.oauth2.client.request.OAuthClientRequest;

--- a/app/src/main/java/be/ugent/zeus/hydra/minerva/auth/requests/RefreshAccessTokenRequest.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/minerva/auth/requests/RefreshAccessTokenRequest.java
@@ -1,9 +1,9 @@
-package be.ugent.zeus.hydra.auth.requests;
+package be.ugent.zeus.hydra.minerva.auth.requests;
 
 import android.util.Log;
 
-import be.ugent.zeus.hydra.auth.MinervaConfig;
-import be.ugent.zeus.hydra.auth.OAuthConfiguration;
+import be.ugent.zeus.hydra.minerva.auth.MinervaConfig;
+import be.ugent.zeus.hydra.minerva.auth.OAuthConfiguration;
 import org.apache.oltu.oauth2.client.OAuthClient;
 import org.apache.oltu.oauth2.client.URLConnectionClient;
 import org.apache.oltu.oauth2.client.request.OAuthClientRequest;

--- a/app/src/main/java/be/ugent/zeus/hydra/minerva/auth/requests/TokenRequestInterceptor.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/minerva/auth/requests/TokenRequestInterceptor.java
@@ -18,7 +18,7 @@
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package be.ugent.zeus.hydra.auth.requests;
+package be.ugent.zeus.hydra.minerva.auth.requests;
 
 import android.util.Log;
 

--- a/app/src/main/java/be/ugent/zeus/hydra/minerva/sync/SyncUtils.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/minerva/sync/SyncUtils.java
@@ -8,8 +8,8 @@ import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.util.Log;
 
-import be.ugent.zeus.hydra.auth.AccountUtils;
-import be.ugent.zeus.hydra.auth.MinervaConfig;
+import be.ugent.zeus.hydra.minerva.auth.AccountUtils;
+import be.ugent.zeus.hydra.minerva.auth.MinervaConfig;
 
 /**
  * @author Niko Strijbol

--- a/app/src/main/java/be/ugent/zeus/hydra/requests/common/TokenRequest.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/requests/common/TokenRequest.java
@@ -1,6 +1,6 @@
 package be.ugent.zeus.hydra.requests.common;
 
-import be.ugent.zeus.hydra.auth.requests.TokenRequestInterceptor;
+import be.ugent.zeus.hydra.minerva.auth.requests.TokenRequestInterceptor;
 import org.springframework.http.client.ClientHttpRequestInterceptor;
 import org.springframework.web.client.RestTemplate;
 

--- a/app/src/main/java/be/ugent/zeus/hydra/requests/minerva/MinervaRequest.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/requests/minerva/MinervaRequest.java
@@ -9,8 +9,8 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.util.Log;
 
-import be.ugent.zeus.hydra.auth.AccountUtils;
-import be.ugent.zeus.hydra.auth.MinervaConfig;
+import be.ugent.zeus.hydra.minerva.auth.AccountUtils;
+import be.ugent.zeus.hydra.minerva.auth.MinervaConfig;
 import be.ugent.zeus.hydra.requests.common.RequestFailureException;
 import be.ugent.zeus.hydra.requests.common.TokenException;
 import be.ugent.zeus.hydra.requests.common.TokenRequest;
@@ -26,7 +26,7 @@ public abstract class MinervaRequest<T> extends TokenRequest<T> {
 
     private static final String TAG = "MinervaRequest";
 
-    protected static final String MINERVA_API = "https://minqas.ugent.be/api/rest/v2/";
+    protected static final String MINERVA_API = "https://minerva.ugent.be/api/rest/v2/";
 
     protected final Context context;
     protected final Activity activity;

--- a/app/src/main/java/be/ugent/zeus/hydra/requests/minerva/UserInfoRequest.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/requests/minerva/UserInfoRequest.java
@@ -2,8 +2,8 @@ package be.ugent.zeus.hydra.requests.minerva;
 
 import android.support.annotation.NonNull;
 
-import be.ugent.zeus.hydra.auth.MinervaConfig;
-import be.ugent.zeus.hydra.auth.models.GrantInformation;
+import be.ugent.zeus.hydra.minerva.auth.MinervaConfig;
+import be.ugent.zeus.hydra.minerva.auth.models.GrantInformation;
 import be.ugent.zeus.hydra.requests.common.TokenRequest;
 
 /**


### PR DESCRIPTION
Update endpoints to the production ones.

I've taken the opportunity to move the `auth` package under the `minerva` package, now everything related to minerva (except fragments & activities) is under one package (sync, database, auth).