### PR TITLE
Improvements & fixes for associations

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -64,7 +64,7 @@ dependencies {
     compile 'com.google.code.gson:gson:2.6.2'
     compile 'com.timehop.stickyheadersrecyclerview:library:0.4.3@aar'
     compile 'com.jakewharton.threetenabp:threetenabp:1.0.4'
-    compile 'com.google.android.gms:play-services-analytics:9.4.0'
+    compile 'com.google.android.gms:play-services-analytics:9.6.1'
     compile 'com.squareup.picasso:picasso:2.5.2'
     compile 'com.github.KyoSherlock:expandablelayout:master-SNAPSHOT'
     compile 'com.github.pluscubed:recycler-fast-scroll:0.3.1@aar'
@@ -81,9 +81,9 @@ dependencies {
     }
 
     //compile 'com.google.firebase:firebase-core:9.4.0'
-    //compile 'com.google.firebase:firebase-crash:9.4.0'
-    compile 'com.google.firebase:firebase-messaging:9.4.0'
-    compile 'com.google.firebase:firebase-config:9.4.0'
+    releaseCompile 'com.google.firebase:firebase-crash:9.6.1'
+    compile 'com.google.firebase:firebase-messaging:9.6.1'
+    compile 'com.google.firebase:firebase-config:9.6.1'
 
     compile 'su.j2e:rv-joiner:1.0.9'
 

--- a/app/src/main/java/be/ugent/zeus/hydra/activities/ActivityDetailActivity.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/activities/ActivityDetailActivity.java
@@ -6,6 +6,8 @@ import android.os.Bundle;
 import android.os.Parcelable;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.app.ActivityOptionsCompat;
+import android.support.v4.text.util.LinkifyCompat;
+import android.text.util.Linkify;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -67,6 +69,7 @@ public class ActivityDetailActivity extends ToolbarActivity implements View.OnCl
 
         if(event.getDescription() != null && !event.getDescription().trim().isEmpty()) {
             description.setText(event.getDescription());
+            LinkifyCompat.addLinks(description, Linkify.ALL);
         }
 
         if(event.hasLocation()) {

--- a/app/src/main/java/be/ugent/zeus/hydra/activities/preferences/AssociationSelectPrefActivity.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/activities/preferences/AssociationSelectPrefActivity.java
@@ -110,9 +110,9 @@ public class AssociationSelectPrefActivity extends LoaderToolbarActivity<Associa
 
         //Save the values.
         Set<String> disabled = new HashSet<>();
-        for (Pair<Association, Boolean> pair: adapter.getItems()) {
-            if(!pair.second) {
-                disabled.add(pair.first.getInternalName());
+        for (Map.Entry<Association, Boolean> pair: adapter.allData.entrySet()) {
+            if(!pair.getValue()) {
+                disabled.add(pair.getKey().getInternalName());
             }
         }
 
@@ -122,12 +122,29 @@ public class AssociationSelectPrefActivity extends LoaderToolbarActivity<Associa
 
     private static class SearchableAdapter extends MultiSelectListAdapter<Association> implements SearchView.OnQueryTextListener, SectionTitleProvider {
 
-        private List<Pair<Association, Boolean>> allData;
+        private Map<Association, Boolean> allData = new HashMap<>();
 
         @Override
         public void setItems(List<Pair<Association, Boolean>> list) {
             super.setItems(list);
-            allData = list;
+            for(Pair<Association, Boolean> pair: list) {
+                allData.put(pair.first, pair.second);
+            }
+        }
+
+        @Override
+        public void setChecked(int position) {
+            super.setChecked(position);
+            Pair<Association, Boolean> newData = items.get(position);
+            allData.put(newData.first, newData.second);
+        }
+
+        @Override
+        public void setAllChecked(boolean checked) {
+            super.setAllChecked(checked);
+            for(Association key: allData.keySet()) {
+                allData.put(key, checked);
+            }
         }
 
         @Override
@@ -143,17 +160,21 @@ public class AssociationSelectPrefActivity extends LoaderToolbarActivity<Associa
             }
 
             if(newText.isEmpty()) {
-                this.items = allData;
+                List<Pair<Association, Boolean>> newList = new ArrayList<>();
+                for(Map.Entry<Association, Boolean> pair: allData.entrySet()) {
+                    newList.add(new Pair<>(pair.getKey(), pair.getValue()));
+                }
+                this.items = newList;
                 notifyDataSetChanged();
             }
 
             List<Pair<Association, Boolean>> newList = new ArrayList<>();
 
-            for(Pair<Association, Boolean> pair: allData) {
-                Association a = pair.first;
+            for(Map.Entry<Association, Boolean> pair: allData.entrySet()) {
                 String text = newText.toLowerCase();
+                Association a = pair.getKey();
                 if(a.getDisplayName().toLowerCase().contains(text) || (a.getFullName() != null && a.getFullName().toLowerCase().contains(text))) {
-                    newList.add(pair);
+                    newList.add(new Pair<>(a, pair.getValue()));
                 }
             }
 

--- a/app/src/main/java/be/ugent/zeus/hydra/activities/preferences/AssociationSelectPrefActivity.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/activities/preferences/AssociationSelectPrefActivity.java
@@ -173,7 +173,9 @@ public class AssociationSelectPrefActivity extends LoaderToolbarActivity<Associa
             for(Map.Entry<Association, Boolean> pair: allData.entrySet()) {
                 String text = newText.toLowerCase();
                 Association a = pair.getKey();
-                if(a.getDisplayName().toLowerCase().contains(text) || (a.getFullName() != null && a.getFullName().toLowerCase().contains(text))) {
+                if(a.getDisplayName().toLowerCase().contains(text) ||
+                        (a.getFullName() != null && a.getFullName().toLowerCase().contains(text)) ||
+                        a.getInternalName().toLowerCase().contains(text)) {
                     newList.add(new Pair<>(a, pair.getValue()));
                 }
             }

--- a/app/src/main/java/be/ugent/zeus/hydra/fragments/home/EventCallback.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/fragments/home/EventCallback.java
@@ -9,7 +9,7 @@ import be.ugent.zeus.hydra.models.association.Activity;
 import be.ugent.zeus.hydra.models.cards.AssociationActivityCard;
 import be.ugent.zeus.hydra.models.cards.HomeCard;
 import be.ugent.zeus.hydra.recyclerview.adapters.HomeCardAdapter;
-import be.ugent.zeus.hydra.requests.ActivitiesRequest;
+import be.ugent.zeus.hydra.requests.events.ActivitiesRequest;
 import org.threeten.bp.ZonedDateTime;
 
 import java.util.ArrayList;

--- a/app/src/main/java/be/ugent/zeus/hydra/models/association/Activities.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/models/association/Activities.java
@@ -23,7 +23,7 @@ public class Activities extends ArrayList<Activity> {
      * class. While not optimal, this is a consequence of the type erasure of Java. This should be solved in Java 9, so
      * we'll probably see it in Android in 2050 or so.
      *
-     * @param data The data to filter. This list is not touched.
+     * @param data The data to filter.
      * @param context The context.
      */
     public static List<Activity> filterActivities(List<Activity> data, Context context) {

--- a/app/src/main/java/be/ugent/zeus/hydra/models/association/Association.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/models/association/Association.java
@@ -2,14 +2,21 @@ package be.ugent.zeus.hydra.models.association;
 
 import android.os.Parcel;
 import android.os.Parcelable;
+import android.support.annotation.NonNull;
 
-import java.io.Serializable;
 import com.google.gson.annotations.SerializedName;
 
-/**
- * Created by feliciaan on 04/02/16.
- */
+import java.io.Serializable;
 
+/**
+ * Represents an association registered with the DSA.
+ *
+ * An association is identified by it's internal name. If the internal name is the same, the association is the same.
+ * Both the hash and equals method are implemented for this class.
+ *
+ * @author feliciaan
+ * @author Niko Strijbol
+ */
 public class Association implements Parcelable, Serializable {
 
     @SerializedName("internal_name")
@@ -21,13 +28,14 @@ public class Association implements Parcelable, Serializable {
     @SerializedName("parent_association")
     private String parentAssociation;
 
-    protected Association(Parcel in) {
-        internalName = in.readString();
-        fullName = in.readString();
-        displayName = in.readString();
-        parentAssociation = in.readString();
+    @SuppressWarnings("unused")
+    private Association() {
+        //GSON no args constructor
     }
 
+    /**
+     * @return A name for this association. If a full name is available, that is returned. If not, the display name is.
+     */
     public String getName() {
         if (fullName != null) {
             return fullName;
@@ -35,36 +43,41 @@ public class Association implements Parcelable, Serializable {
         return displayName;
     }
 
+    @NonNull
     public String getInternalName() {
         return internalName;
-    }
-
-    public void setInternalName(String internalName) {
-        this.internalName = internalName;
     }
 
     public String getFullName() {
         return fullName;
     }
 
-    public void setFullName(String fullName) {
-        this.fullName = fullName;
-    }
-
     public String getDisplayName() {
         return displayName;
-    }
-
-    public void setDisplayName(String displayName) {
-        this.displayName = displayName;
     }
 
     public String getParentAssociation() {
         return parentAssociation;
     }
 
-    public void setParentAssociation(String parentAssociation) {
-        this.parentAssociation = parentAssociation;
+    public String getImageLink() {
+        return "https://zeus.ugent.be/hydra/api/2.0/association/logo/" + internalName.toLowerCase() + ".png";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Association that = (Association) o;
+
+        return internalName.equals(that.internalName);
+
+    }
+
+    @Override
+    public int hashCode() {
+        return internalName.hashCode();
     }
 
     public static final Creator<Association> CREATOR = new Creator<Association>() {
@@ -92,11 +105,10 @@ public class Association implements Parcelable, Serializable {
         dest.writeString(parentAssociation);
     }
 
-    public String getImageLink() {
-        if(internalName == null) {
-            return null;
-        }
-        
-        return "https://zeus.ugent.be/hydra/api/2.0/association/logo/" + internalName.toLowerCase() + ".png";
+    protected Association(Parcel in) {
+        internalName = in.readString();
+        fullName = in.readString();
+        displayName = in.readString();
+        parentAssociation = in.readString();
     }
 }

--- a/app/src/main/java/be/ugent/zeus/hydra/recyclerview/adapters/ActivityListAdapter.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/recyclerview/adapters/ActivityListAdapter.java
@@ -1,88 +1,37 @@
 package be.ugent.zeus.hydra.recyclerview.adapters;
 
-import android.content.Intent;
-import android.os.Parcelable;
-import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.TextView;
 
 import be.ugent.zeus.hydra.R;
-import be.ugent.zeus.hydra.activities.ActivityDetailActivity;
 import be.ugent.zeus.hydra.models.association.Activity;
+import be.ugent.zeus.hydra.recyclerview.adapters.common.ItemAdapter;
+import be.ugent.zeus.hydra.recyclerview.viewholder.ActivityViewHolder;
 import be.ugent.zeus.hydra.recyclerview.viewholder.DateHeaderViewHolder;
 import com.timehop.stickyheadersrecyclerview.StickyRecyclerHeadersAdapter;
-import org.threeten.bp.LocalDateTime;
-import org.threeten.bp.format.DateTimeFormatter;
-
-import java.util.Collections;
-import java.util.List;
-
-import static be.ugent.zeus.hydra.utils.ViewUtils.$;
 
 /**
  * Adapter for the list of activities.
  *
  * @author ellen
+ * @author Niko Strijbol
  */
-public class ActivityListAdapter extends RecyclerView.Adapter<ActivityListAdapter.CardViewHolder> implements StickyRecyclerHeadersAdapter<DateHeaderViewHolder> {
-
-    private static final DateTimeFormatter INTEGER_FORMATTER = DateTimeFormatter.ofPattern("ddMMyyyy");
-    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
-
-    public static class CardViewHolder extends RecyclerView.ViewHolder {
-
-        private TextView start;
-        private TextView title;
-        private TextView association;
-
-        private CardViewHolder(View v) {
-            super(v);
-            title = $(v, R.id.name);
-            association = $(v, R.id.association);
-            start = $(v, R.id.starttime);
-        }
-
-        private void populate(final Activity activity) {
-            title.setText(activity.getTitle());
-            association.setText(activity.getAssociation().getDisplayName());
-            start.setText(activity.getLocalStart().format(FORMATTER));
-            itemView.setOnClickListener(new View.OnClickListener() {
-                @Override
-                public void onClick(View v) {
-                    Intent intent = new Intent(itemView.getContext(), ActivityDetailActivity.class);
-                    intent.putExtra(ActivityDetailActivity.PARCEL_EVENT, (Parcelable) activity);
-                    itemView.getContext().startActivity(intent);
-                }
-            });
-        }
-    }
-
-    private List<Activity> data = Collections.emptyList();
-    private List<Activity> original = Collections.emptyList();
-
+public class ActivityListAdapter extends ItemAdapter<Activity, ActivityViewHolder> implements StickyRecyclerHeadersAdapter<DateHeaderViewHolder> {
 
     @Override
-    public CardViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+    public ActivityViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
         View v = LayoutInflater.from(parent.getContext())
                 .inflate(R.layout.item_activity, parent, false);
-        return new CardViewHolder(v);
-    }
-
-    @Override
-    public void onBindViewHolder(CardViewHolder holder, int position) {
-        final Activity restoCategory = data.get(position);
-        holder.populate(restoCategory);
+        return new ActivityViewHolder(v);
     }
 
     /**
-     * We want to sort per day,
+     * We want to sort per day.
      */
     @Override
     public long getHeaderId(int position) {
-        LocalDateTime date = data.get(position).getLocalStart();
-        return Integer.parseInt(date.format(INTEGER_FORMATTER));
+        return items.get(position).getStart().toEpochSecond();
     }
 
     @Override
@@ -94,27 +43,6 @@ public class ActivityListAdapter extends RecyclerView.Adapter<ActivityListAdapte
 
     @Override
     public void onBindHeaderViewHolder(DateHeaderViewHolder holder, int position) {
-        holder.populate(data.get(position).getStart());
-    }
-
-    @Override
-    public int getItemCount() {
-        return data.size();
-    }
-
-    public void setData(List<Activity> data) {
-        this.data = data;
-    }
-
-    public List<Activity> getData() {
-        return data;
-    }
-
-    public void setOriginal(List<Activity> data) {
-        this.original = data;
-    }
-
-    public List<Activity> getOriginal() {
-        return original;
+        holder.populate(items.get(position).getStart());
     }
 }

--- a/app/src/main/java/be/ugent/zeus/hydra/recyclerview/adapters/MultiSelectListAdapter.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/recyclerview/adapters/MultiSelectListAdapter.java
@@ -5,7 +5,6 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.CheckBox;
-import android.widget.CompoundButton;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
@@ -60,18 +59,17 @@ public class MultiSelectListAdapter<H> extends ItemAdapter<Pair<H, Boolean>, Mul
     }
 
     /**
-     * Change the boolean value at the given position to the given value. This operation DOES NOT trigger a change
+     * Change the boolean value at the given position to the reverse value. This operation DOES NOT trigger a change
      * in the recycler view data, so the methods for changed items is not called. The rationale behind this is that
      * this method is meant to be attached to a checkbox as a listener. Then the checkbox is already updated.
      *
      * Implementation note: the value at the position is replaced with a new instance.
      *
      * @param position The position.
-     * @param checked The value.
      */
-    public void setChecked(int position, boolean checked) {
-        H value = items.get(position).first;
-        items.set(position, new Pair<>(value, checked));
+    public void setChecked(int position) {
+        Pair<H, Boolean> old = items.get(position);
+        items.set(position, new Pair<>(old.first, !old.second));
     }
 
     /**
@@ -137,13 +135,14 @@ public class MultiSelectListAdapter<H> extends ItemAdapter<Pair<H, Boolean>, Mul
             parent.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
+                    adapter.setChecked(getAdapterPosition());
                     checkBox.toggle();
                 }
             });
-            checkBox.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+            checkBox.setOnClickListener(new View.OnClickListener() {
                 @Override
-                public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
-                    adapter.setChecked(getAdapterPosition(), isChecked);
+                public void onClick(View v) {
+                    adapter.setChecked(getAdapterPosition());
                 }
             });
         }

--- a/app/src/main/java/be/ugent/zeus/hydra/recyclerview/viewholder/ActivityViewHolder.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/recyclerview/viewholder/ActivityViewHolder.java
@@ -1,0 +1,48 @@
+package be.ugent.zeus.hydra.recyclerview.viewholder;
+
+import android.content.Intent;
+import android.os.Parcelable;
+import android.view.View;
+import android.widget.TextView;
+
+import be.ugent.zeus.hydra.R;
+import be.ugent.zeus.hydra.activities.ActivityDetailActivity;
+import be.ugent.zeus.hydra.models.association.Activity;
+import org.threeten.bp.format.DateTimeFormatter;
+
+import static be.ugent.zeus.hydra.utils.ViewUtils.$;
+
+/**
+ * View holder for an event in the event tab.
+ *
+ * @author Niko Strijbol
+ */
+public class ActivityViewHolder extends DataViewHolder<Activity> {
+
+    private static final DateTimeFormatter HOUR_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
+
+    private TextView start;
+    private TextView title;
+    private TextView association;
+
+    public ActivityViewHolder(View v) {
+        super(v);
+        title = $(v, R.id.name);
+        association = $(v, R.id.association);
+        start = $(v, R.id.starttime);
+    }
+
+    public void populate(final Activity activity) {
+        title.setText(activity.getTitle());
+        association.setText(activity.getAssociation().getDisplayName());
+        start.setText(activity.getLocalStart().format(HOUR_FORMATTER));
+        itemView.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                Intent intent = new Intent(itemView.getContext(), ActivityDetailActivity.class);
+                intent.putExtra(ActivityDetailActivity.PARCEL_EVENT, (Parcelable) activity);
+                itemView.getContext().startActivity(intent);
+            }
+        });
+    }
+}

--- a/app/src/main/java/be/ugent/zeus/hydra/requests/common/ProcessableCacheRequest.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/requests/common/ProcessableCacheRequest.java
@@ -17,7 +17,7 @@ import java.io.Serializable;
  */
 public abstract class ProcessableCacheRequest<D extends Serializable, R> implements Request<R> {
 
-    private final Context context;
+    protected final Context context;
     private final CacheRequest<D> cacheRequest;
     private boolean shouldRefresh;
 

--- a/app/src/main/java/be/ugent/zeus/hydra/requests/events/ActivitiesRequest.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/requests/events/ActivitiesRequest.java
@@ -1,4 +1,4 @@
-package be.ugent.zeus.hydra.requests;
+package be.ugent.zeus.hydra.requests.events;
 
 import android.support.annotation.NonNull;
 

--- a/app/src/main/java/be/ugent/zeus/hydra/requests/events/FilteredEventRequest.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/requests/events/FilteredEventRequest.java
@@ -1,0 +1,26 @@
+package be.ugent.zeus.hydra.requests.events;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+
+import be.ugent.zeus.hydra.models.association.Activities;
+import be.ugent.zeus.hydra.requests.common.ProcessableCacheRequest;
+
+/**
+ * A request that filters the events according to the user's preferences.
+ *
+ * @author Niko Strijbol
+ */
+public class FilteredEventRequest extends ProcessableCacheRequest<Activities, Activities> {
+
+    public FilteredEventRequest(Context context, boolean shouldRefresh) {
+        super(context, new ActivitiesRequest(), shouldRefresh);
+    }
+
+    @NonNull
+    @Override
+    protected Activities transform(@NonNull Activities data) {
+        Activities.filterActivities(data, context);
+        return data;
+    }
+}


### PR DESCRIPTION
The search in the association selection activity messed up saving the correct associations. This should fix that. Views are also updated after changes are made now.

This also improves the search a bit (e.g. searching `vtk` now works) and adds clickable links in the event descriptions (e.g. the Zeus S10 visit text).

Fixes #108 