### PR TITLE
Add Minerva agenda to homefeed

### DIFF
--- a/app/src/main/java/be/ugent/zeus/hydra/activities/minerva/AgendaActivity.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/activities/minerva/AgendaActivity.java
@@ -1,7 +1,9 @@
 package be.ugent.zeus.hydra.activities.minerva;
 
+import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
+import android.os.Parcelable;
 import android.provider.CalendarContract;
 import android.support.annotation.Nullable;
 import android.text.TextUtils;
@@ -104,5 +106,11 @@ public class AgendaActivity extends ToolbarActivity {
             intent.putExtra(CalendarContract.Events.EVENT_LOCATION, agendaItem.getLocation());
         }
         startActivity(intent);
+    }
+
+    public static void start(Context context, AgendaItem agendaItem) {
+        Intent intent = new Intent(context, AgendaActivity.class);
+        intent.putExtra(AgendaActivity.ARG_AGENDA_ITEM, (Parcelable) agendaItem);
+        context.startActivity(intent);
     }
 }

--- a/app/src/main/java/be/ugent/zeus/hydra/fragments/home/HomeFeedFragment.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/fragments/home/HomeFeedFragment.java
@@ -180,9 +180,15 @@ public class HomeFeedFragment extends Fragment implements SharedPreferences.OnSh
             onPartialResult(Collections.<HomeCard>emptyList(), HomeCard.CardType.NEWS_ITEM);
         }
         if(isTypeActive(HomeCard.CardType.MINERVA_ANNOUNCEMENT) && AccountUtils.hasAccount(getContext())) {
-            loader.addRequest(new MinervaDoaRequest(getContext()));
+            loader.addRequest(new MinervaAnnouncementRequest(getContext()));
         } else {
             onPartialResult(Collections.<HomeCard>emptyList(), HomeCard.CardType.MINERVA_ANNOUNCEMENT);
+        }
+
+        if(isTypeActive(HomeCard.CardType.MINERVA_AGENDA) && AccountUtils.hasAccount(getContext())) {
+            loader.addRequest(new MinervaAgendaRequest(getContext()));
+        } else {
+            onPartialResult(Collections.<HomeCard>emptyList(), HomeCard.CardType.MINERVA_AGENDA);
         }
 
         return loader;

--- a/app/src/main/java/be/ugent/zeus/hydra/fragments/home/requests/EventRequest.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/fragments/home/requests/EventRequest.java
@@ -5,7 +5,7 @@ import android.support.annotation.NonNull;
 
 import be.ugent.zeus.hydra.models.association.Event;
 import be.ugent.zeus.hydra.models.association.Events;
-import be.ugent.zeus.hydra.models.cards.AssociationActivityCard;
+import be.ugent.zeus.hydra.models.cards.EventCard;
 import be.ugent.zeus.hydra.models.cards.HomeCard;
 import be.ugent.zeus.hydra.requests.common.ProcessableCacheRequest;
 import org.threeten.bp.ZonedDateTime;
@@ -31,7 +31,7 @@ public class EventRequest extends ProcessableCacheRequest<Events, List<HomeCard>
         ZonedDateTime now = ZonedDateTime.now();
         List<HomeCard> list = new ArrayList<>();
         for (Event event : data) {
-            AssociationActivityCard activityCard = new AssociationActivityCard(event);
+            EventCard activityCard = new EventCard(event);
             if (activityCard.getPriority() > 0 && event.getStart().isAfter(now)) {
                 list.add(activityCard);
             }

--- a/app/src/main/java/be/ugent/zeus/hydra/fragments/home/requests/MinervaAgendaRequest.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/fragments/home/requests/MinervaAgendaRequest.java
@@ -9,10 +9,14 @@ import be.ugent.zeus.hydra.models.cards.MinervaAgendaCard;
 import be.ugent.zeus.hydra.models.minerva.AgendaItem;
 import be.ugent.zeus.hydra.requests.common.Request;
 import be.ugent.zeus.hydra.requests.exceptions.RequestFailureException;
+import be.ugent.zeus.hydra.utils.DateUtils;
 import org.threeten.bp.Instant;
+import org.threeten.bp.LocalDate;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Request for Minerva agenda items.
@@ -33,8 +37,20 @@ public class MinervaAgendaRequest implements Request<List<HomeCard>>, HomeFeedRe
         List<AgendaItem> list = dao.getFutureAgenda(Instant.now());
         List<HomeCard> cards = new ArrayList<>();
 
+        //Sort the agenda items per day
+        Map<LocalDate, List<AgendaItem>> map = new HashMap<>();
+
         for (AgendaItem item: list) {
-            cards.add(new MinervaAgendaCard(item));
+
+            if(!map.containsKey(DateUtils.toLocalDateTime(item.getStartDate()).toLocalDate())) {
+                map.put(DateUtils.toLocalDateTime(item.getStartDate()).toLocalDate(), new ArrayList<AgendaItem>());
+            }
+
+            map.get(DateUtils.toLocalDateTime(item.getStartDate()).toLocalDate()).add(item);
+        }
+
+        for (Map.Entry<LocalDate, List<AgendaItem>> itemEntry: map.entrySet()) {
+            cards.add(new MinervaAgendaCard(itemEntry.getKey(), itemEntry.getValue()));
         }
 
         return cards;

--- a/app/src/main/java/be/ugent/zeus/hydra/fragments/home/requests/MinervaAgendaRequest.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/fragments/home/requests/MinervaAgendaRequest.java
@@ -1,0 +1,47 @@
+package be.ugent.zeus.hydra.fragments.home.requests;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+
+import be.ugent.zeus.hydra.minerva.agenda.AgendaDao;
+import be.ugent.zeus.hydra.models.cards.HomeCard;
+import be.ugent.zeus.hydra.models.cards.MinervaAgendaCard;
+import be.ugent.zeus.hydra.models.minerva.AgendaItem;
+import be.ugent.zeus.hydra.requests.common.Request;
+import be.ugent.zeus.hydra.requests.exceptions.RequestFailureException;
+import org.threeten.bp.Instant;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Request for Minerva agenda items.
+ *
+ * @author Niko Strijbol
+ */
+public class MinervaAgendaRequest implements Request<List<HomeCard>>, HomeFeedRequest {
+
+    private final AgendaDao dao;
+
+    public MinervaAgendaRequest(Context context) {
+        this.dao = new AgendaDao(context);
+    }
+
+    @NonNull
+    @Override
+    public List<HomeCard> performRequest() throws RequestFailureException {
+        List<AgendaItem> list = dao.getFutureAgenda(Instant.now());
+        List<HomeCard> cards = new ArrayList<>();
+
+        for (AgendaItem item: list) {
+            cards.add(new MinervaAgendaCard(item));
+        }
+
+        return cards;
+    }
+
+    @Override
+    public int getCardType() {
+        return HomeCard.CardType.MINERVA_AGENDA;
+    }
+}

--- a/app/src/main/java/be/ugent/zeus/hydra/fragments/home/requests/MinervaAnnouncementRequest.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/fragments/home/requests/MinervaAnnouncementRequest.java
@@ -18,11 +18,11 @@ import java.util.Map;
 /**
  * @author Niko Strijbol
  */
-public class MinervaDoaRequest implements Request<List<HomeCard>>, HomeFeedRequest {
+public class MinervaAnnouncementRequest implements Request<List<HomeCard>>, HomeFeedRequest {
 
     private final AnnouncementDao dao;
 
-    public MinervaDoaRequest(Context context) {
+    public MinervaAnnouncementRequest(Context context) {
         this.dao = new AnnouncementDao(context);
     }
 

--- a/app/src/main/java/be/ugent/zeus/hydra/minerva/agenda/AgendaExtractor.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/minerva/agenda/AgendaExtractor.java
@@ -1,0 +1,188 @@
+package be.ugent.zeus.hydra.minerva.agenda;
+
+import android.database.Cursor;
+import android.support.annotation.NonNull;
+
+import be.ugent.zeus.hydra.models.minerva.AgendaItem;
+import be.ugent.zeus.hydra.models.minerva.Course;
+import be.ugent.zeus.hydra.utils.TtbUtils;
+
+/**
+ * Class to extract a {@link AgendaItem} from a {@link Cursor}.
+ *
+ * This class should be set up once per database request. Build this class with the builder class.
+ *
+ * The builder class needs to be provided with the Cursor. Note that this class does NOT advance the cursor.
+ *
+ * @author Niko Strijbol
+ */
+class AgendaExtractor {
+
+    private int columnIndex;
+    private int columnTitle;
+    private int columnContent;
+    private int columnStartDate;
+    private int columnEndDate;
+    private int columnLocation;
+    private int columnType;
+    private int columnLastEditUser;
+    private int columnLastEdit;
+    private int columnLastEditType;
+
+    private final Cursor cursor;
+
+    private AgendaExtractor(Cursor cursor) {
+        this.cursor = cursor;
+    }
+
+    /**
+     * Get an announcement from the cursor. To re-iterate, this does NOT affect the position of the cursor in any way.
+     *
+     * @return The announcement.
+     */
+    public AgendaItem getAgendaItem(Course course) {
+        AgendaItem a = new AgendaItem();
+        a.setCourse(course);
+        a.setItemId(cursor.getInt(columnIndex));
+        a.setTitle(cursor.getString(columnTitle));
+        a.setContent(cursor.getString(columnContent));
+        a.setStartDate(TtbUtils.unserialize(cursor.getLong(columnStartDate)));
+        a.setEndDate(TtbUtils.unserialize(cursor.getLong(columnEndDate)));
+        a.setLocation(cursor.getString(columnLocation));
+        a.setType(cursor.getString(columnType));
+        a.setLastEditUser(cursor.getString(columnLastEditUser));
+        a.setLastEdited(TtbUtils.unserialize(cursor.getLong(columnLastEdit)));
+        a.setLastEditType(cursor.getString(columnLastEditType));
+
+        return a;
+    }
+
+    public int getColumnIndex() {
+        return columnIndex;
+    }
+
+    public int getColumnTitle() {
+        return columnTitle;
+    }
+
+    public int getColumnContent() {
+        return columnContent;
+    }
+
+    public int getColumnStartDate() {
+        return columnStartDate;
+    }
+
+    public int getColumnEndDate() {
+        return columnEndDate;
+    }
+
+    public int getColumnLocation() {
+        return columnLocation;
+    }
+
+    public int getColumnType() {
+        return columnType;
+    }
+
+    public int getColumnLastEditUser() {
+        return columnLastEditUser;
+    }
+
+    public int getColumnLastEdit() {
+        return columnLastEdit;
+    }
+
+    public int getColumnLastEditType() {
+        return columnLastEditType;
+    }
+
+    /**
+     * Builder class.
+     */
+    @SuppressWarnings("unused")
+    public static class Builder {
+
+        private final AgendaExtractor extractor;
+
+        public Builder(@NonNull Cursor cursor) {
+            this.extractor = new AgendaExtractor(cursor);
+        }
+
+        /**
+         * Set every column int to the default value. The default value is the column name in the database table.
+         */
+        public Builder defaults() {
+            extractor.columnIndex = extract(AgendaTable.COLUMN_ID);
+            extractor.columnTitle = extract(AgendaTable.COLUMN_TITLE);
+            extractor.columnContent = extract(AgendaTable.COLUMN_CONTENT);
+            extractor.columnStartDate = extract(AgendaTable.COLUMN_START_DATE);
+            extractor.columnEndDate = extract(AgendaTable.COLUMN_END_DATE);
+            extractor.columnLocation = extract(AgendaTable.COLUMN_LOCATION);
+            extractor.columnType = extract(AgendaTable.COLUMN_TYPE);
+            extractor.columnLastEditUser = extract(AgendaTable.COLUMN_LAST_EDIT_USER);
+            extractor.columnLastEdit = extract(AgendaTable.COLUMN_LAST_EDIT);
+            extractor.columnLastEditType = extract(AgendaTable.COLUMN_LAST_EDIT_TYPE);
+            return this;
+        }
+
+        private int extract(String column) {
+            return extractor.cursor.getColumnIndexOrThrow(column);
+        }
+
+        public Builder columnIndex(String columnIndex) {
+            extractor.columnIndex = extract(columnIndex);
+            return this;
+        }
+
+        public Builder columnTitle(String columnTitle) {
+            extractor.columnTitle = extract(columnTitle);
+            return this;
+        }
+
+        public Builder columnContent(String columnContent) {
+            extractor.columnContent = extract(columnContent);
+            return this;
+        }
+
+        public Builder columnStartDate(String columnName) {
+            extractor.columnStartDate = extract(columnName);
+            return this;
+        }
+
+        public Builder columnEndDate(String columnName) {
+            extractor.columnEndDate = extract(columnName);
+            return this;
+        }
+
+        public Builder columnLocation(String columnName) {
+            extractor.columnLocation = extract(columnName);
+            return this;
+        }
+
+        public Builder columnType(String columnName) {
+            extractor.columnType = extract(columnName);
+            return this;
+        }
+
+        public Builder columnLastEditUser(String columnName) {
+            extractor.columnLastEditUser = extract(columnName);
+            return this;
+        }
+
+        public Builder columnLastEdit(String columnName) {
+            extractor.columnLastEdit = extract(columnName);
+            return this;
+        }
+
+        public Builder columnLastEditType(String columnName) {
+            extractor.columnLastEditType = extract(columnName);
+            return this;
+        }
+
+
+        public AgendaExtractor build() {
+            return extractor;
+        }
+    }
+}

--- a/app/src/main/java/be/ugent/zeus/hydra/models/cards/EventCard.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/models/cards/EventCard.java
@@ -5,13 +5,15 @@ import org.threeten.bp.Duration;
 import org.threeten.bp.ZonedDateTime;
 
 /**
- * Created by silox on 18/04/16.
+ * Show association event.
+ *
+ * @author silox
  */
-public class AssociationActivityCard extends HomeCard {
+public class EventCard extends HomeCard {
 
     private Event event;
 
-    public AssociationActivityCard(Event event) {
+    public EventCard(Event event) {
         this.event = event;
     }
 

--- a/app/src/main/java/be/ugent/zeus/hydra/models/cards/HomeCard.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/models/cards/HomeCard.java
@@ -27,7 +27,7 @@ public abstract class HomeCard {
      * Android is horrible with enums, since Google doesn't know what they are doing apparently. Sigh.
      */
     @Retention(RetentionPolicy.SOURCE)
-    @IntDef({RESTO, ACTIVITY, SPECIAL_EVENT, SCHAMPER, NEWS_ITEM, MINERVA_LOGIN, MINERVA_ANNOUNCEMENT})
+    @IntDef({RESTO, ACTIVITY, SPECIAL_EVENT, SCHAMPER, NEWS_ITEM, MINERVA_LOGIN, MINERVA_ANNOUNCEMENT, MINERVA_AGENDA})
     public @interface CardType {
         int RESTO = 1;
         int ACTIVITY = 2;
@@ -36,6 +36,7 @@ public abstract class HomeCard {
         int NEWS_ITEM = 5;
         int MINERVA_LOGIN = 6;
         int MINERVA_ANNOUNCEMENT = 7;
+        int MINERVA_AGENDA = 8;
     }
 
     /**

--- a/app/src/main/java/be/ugent/zeus/hydra/models/cards/MinervaAgendaCard.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/models/cards/MinervaAgendaCard.java
@@ -1,0 +1,34 @@
+package be.ugent.zeus.hydra.models.cards;
+
+import be.ugent.zeus.hydra.models.minerva.AgendaItem;
+import org.threeten.bp.*;
+
+/**
+ * Card to show Minerva agenda item.
+ *
+ * @author Niko Strijbol
+ */
+public class MinervaAgendaCard extends HomeCard {
+
+    private final AgendaItem agenda;
+
+    public MinervaAgendaCard(AgendaItem announcement) {
+        this.agenda = announcement;
+    }
+
+    @Override
+    public int getPriority() {
+        Duration duration = Duration.between(ZonedDateTime.now(), agenda.getStartDate());
+        return 950 - Math.max(0, (int) duration.toHours()) * 4; //see 10 days in to the future
+    }
+
+    public AgendaItem getAgendaItem() {
+        return agenda;
+    }
+
+    @Override
+    @CardType
+    public int getCardType() {
+        return CardType.MINERVA_AGENDA;
+    }
+}

--- a/app/src/main/java/be/ugent/zeus/hydra/models/cards/MinervaAgendaCard.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/models/cards/MinervaAgendaCard.java
@@ -1,7 +1,10 @@
 package be.ugent.zeus.hydra.models.cards;
 
 import be.ugent.zeus.hydra.models.minerva.AgendaItem;
-import org.threeten.bp.*;
+import org.threeten.bp.LocalDate;
+import org.threeten.bp.Period;
+
+import java.util.List;
 
 /**
  * Card to show Minerva agenda item.
@@ -10,20 +13,26 @@ import org.threeten.bp.*;
  */
 public class MinervaAgendaCard extends HomeCard {
 
-    private final AgendaItem agenda;
+    private final LocalDate date;
+    private final List<AgendaItem> agenda;
 
-    public MinervaAgendaCard(AgendaItem announcement) {
-        this.agenda = announcement;
+    public MinervaAgendaCard(LocalDate date, List<AgendaItem> agendaItems) {
+        this.date = date;
+        this.agenda = agendaItems;
     }
 
     @Override
     public int getPriority() {
-        Duration duration = Duration.between(ZonedDateTime.now(), agenda.getStartDate());
-        return 950 - Math.max(0, (int) duration.toHours()) * 4; //see 10 days in to the future
+        Period duration = Period.between(LocalDate.now(), date);
+        return 1000 - (duration.getDays() * 100);
     }
 
-    public AgendaItem getAgendaItem() {
+    public List<AgendaItem> getAgendaItems() {
         return agenda;
+    }
+
+    public LocalDate getDate() {
+        return date;
     }
 
     @Override

--- a/app/src/main/java/be/ugent/zeus/hydra/recyclerview/adapters/HomeCardAdapter.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/recyclerview/adapters/HomeCardAdapter.java
@@ -15,7 +15,7 @@ import be.ugent.zeus.hydra.R;
 import be.ugent.zeus.hydra.activities.preferences.AssociationSelectPrefActivity;
 import be.ugent.zeus.hydra.fragments.home.HomeFeedFragment;
 import be.ugent.zeus.hydra.models.association.Association;
-import be.ugent.zeus.hydra.models.cards.AssociationActivityCard;
+import be.ugent.zeus.hydra.models.cards.EventCard;
 import be.ugent.zeus.hydra.models.cards.HomeCard;
 import be.ugent.zeus.hydra.recyclerview.viewholder.DataViewHolder;
 import be.ugent.zeus.hydra.recyclerview.viewholder.home.*;
@@ -99,6 +99,8 @@ public class HomeCardAdapter extends RecyclerView.Adapter<DataViewHolder<HomeCar
                 return new MinervaLoginViewHolder(getViewForLayout(R.layout.home_minerva_login_card, parent));
             case MINERVA_ANNOUNCEMENT:
                 return new MinervaAnnouncementViewHolder(getViewForLayout(R.layout.home_minerva_announcement_card, parent), this);
+            case MINERVA_AGENDA:
+                return new MinervaAgendaViewHolder(getViewForLayout(R.layout.home_minerva_agenda_card, parent), this);
         }
         return null;
     }
@@ -126,7 +128,7 @@ public class HomeCardAdapter extends RecyclerView.Adapter<DataViewHolder<HomeCar
         while (it.hasNext()) { // Why no filter :(
             HomeCard c = it.next();
             if (c.getCardType() == ACTIVITY) {
-                AssociationActivityCard card = c.checkCard(ACTIVITY);
+                EventCard card = c.checkCard(ACTIVITY);
                 if(card.getEvent().getAssociation().getInternalName().equals(association.getInternalName())) {
                     notifyItemRemoved(cardItems.indexOf(c));
                     it.remove();

--- a/app/src/main/java/be/ugent/zeus/hydra/recyclerview/viewholder/home/EventCardViewHolder.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/recyclerview/viewholder/home/EventCardViewHolder.java
@@ -10,7 +10,7 @@ import android.widget.TextView;
 import be.ugent.zeus.hydra.R;
 import be.ugent.zeus.hydra.activities.ActivityDetailActivity;
 import be.ugent.zeus.hydra.models.association.Event;
-import be.ugent.zeus.hydra.models.cards.AssociationActivityCard;
+import be.ugent.zeus.hydra.models.cards.EventCard;
 import be.ugent.zeus.hydra.models.cards.HomeCard;
 import be.ugent.zeus.hydra.recyclerview.adapters.HomeCardAdapter;
 import be.ugent.zeus.hydra.utils.DateUtils;
@@ -39,7 +39,7 @@ public class EventCardViewHolder extends HideableViewHolder {
     @Override
     public void populate(final HomeCard card) {
 
-        final Event event = card.<AssociationActivityCard>checkCard(HomeCard.CardType.ACTIVITY).getEvent();
+        final Event event = card.<EventCard>checkCard(HomeCard.CardType.ACTIVITY).getEvent();
 
         title.setText(event.getTitle());
         association.setText(event.getLocation());

--- a/app/src/main/java/be/ugent/zeus/hydra/recyclerview/viewholder/home/MinervaAgendaViewHolder.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/recyclerview/viewholder/home/MinervaAgendaViewHolder.java
@@ -1,0 +1,115 @@
+package be.ugent.zeus.hydra.recyclerview.viewholder.home;
+
+import android.content.Context;
+import android.text.TextUtils;
+import android.view.View;
+import android.widget.TextView;
+
+import be.ugent.zeus.hydra.R;
+import be.ugent.zeus.hydra.activities.minerva.AgendaActivity;
+import be.ugent.zeus.hydra.models.cards.HomeCard;
+import be.ugent.zeus.hydra.models.cards.MinervaAgendaCard;
+import be.ugent.zeus.hydra.models.minerva.AgendaItem;
+import be.ugent.zeus.hydra.recyclerview.adapters.HomeCardAdapter;
+import be.ugent.zeus.hydra.utils.DateUtils;
+import org.threeten.bp.ZonedDateTime;
+import org.threeten.bp.format.DateTimeFormatter;
+
+import java.util.Locale;
+
+import static be.ugent.zeus.hydra.utils.ViewUtils.$;
+
+/**
+ * Minerva agenda item.
+ *
+ * @author Niko Strijbol
+ */
+public class MinervaAgendaViewHolder extends HideableViewHolder {
+
+    private static final DateTimeFormatter START_FORMATTER = DateTimeFormatter.ofPattern("dd/MM - HH:mm", new Locale("nl"));
+    private static final DateTimeFormatter HOUR_FORMATTER = DateTimeFormatter.ofPattern("HH:mm", new Locale("nl"));
+
+    private TextView date;
+    private TextView location;
+    private TextView title;
+
+    public MinervaAgendaViewHolder(View v, HomeCardAdapter adapter) {
+        super(v, adapter);
+
+        date = $(v, R.id.date);
+        location = $(v, R.id.location);
+        title = $(v, R.id.title);
+    }
+
+    @Override
+    public void populate(HomeCard card) {
+
+        final MinervaAgendaCard mCard = card.checkCard(HomeCard.CardType.MINERVA_AGENDA);
+        final AgendaItem item = mCard.getAgendaItem();
+
+        toolbar.setTitle("Activiteit van " + item.getCourse().getTitle());
+
+        title.setText(item.getTitle());
+        date.setText(relativeTimeSpan(itemView.getContext(), item.getStartDate(), item.getEndDate()));
+
+        if (TextUtils.isEmpty(item.getLocation())) {
+            location.setVisibility(View.GONE);
+        } else {
+            location.setVisibility(View.VISIBLE);
+            location.setText(item.getLocation());
+        }
+
+        itemView.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                //Set onclick listener
+                AgendaActivity.start(itemView.getContext(), mCard.getAgendaItem());
+            }
+        });
+
+        super.populate(card);
+    }
+
+    /**
+     * Get a relative date string for a start and stop date. The string accounts for events that are on the same day,
+     * by not showing the day twice for example.
+     *
+     * @param start The start date. Should be before the end date.
+     * @param end The end date.
+     * @return The string.
+     */
+    private static String relativeTimeSpan(Context context, ZonedDateTime start, ZonedDateTime end) {
+
+        ZonedDateTime now = ZonedDateTime.now();
+        if(start.isBefore(now) && end.isAfter(now)) {
+            String endString = "";
+            if(android.text.format.DateUtils.isToday(end.toInstant().toEpochMilli())) {
+                endString = end.format(HOUR_FORMATTER);
+            } else {
+                endString = android.text.format.DateUtils.formatDateTime(
+                        context,
+                        end.toInstant().toEpochMilli(),
+                        android.text.format.DateUtils.FORMAT_SHOW_DATE | android.text.format.DateUtils.FORMAT_SHOW_TIME
+                );
+            }
+
+            return "Nu tot " + endString;
+        }
+
+
+        if(start.getDayOfMonth() == end.getDayOfMonth()) {
+            String append = "";
+            if(DateUtils.isThisWeek(start.toLocalDate())) {
+                append = " (" + DateUtils.getFriendlyDate(start.toLocalDate()) + ")";
+            }
+            return DateUtils.relativeDateTimeString(start, context) + " tot " + end.format(HOUR_FORMATTER) + append;
+        } else {
+            return android.text.format.DateUtils.formatDateRange(
+                    context,
+                    start.toInstant().toEpochMilli(),
+                    end.toInstant().toEpochMilli(),
+                    android.text.format.DateUtils.FORMAT_SHOW_DATE | android.text.format.DateUtils.FORMAT_SHOW_TIME
+            );
+        }
+    }
+}

--- a/app/src/main/java/be/ugent/zeus/hydra/recyclerview/viewholder/minerva/AgendaViewHolder.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/recyclerview/viewholder/minerva/AgendaViewHolder.java
@@ -1,7 +1,5 @@
 package be.ugent.zeus.hydra.recyclerview.viewholder.minerva;
 
-import android.content.Intent;
-import android.os.Parcelable;
 import android.view.View;
 import android.widget.TextView;
 
@@ -42,9 +40,7 @@ public class AgendaViewHolder extends DataViewHolder<AgendaItem> {
         parent.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                Intent intent = new Intent(itemView.getContext(), AgendaActivity.class);
-                intent.putExtra(AgendaActivity.ARG_AGENDA_ITEM, (Parcelable) data);
-                itemView.getContext().startActivity(intent);
+                AgendaActivity.start(itemView.getContext(), data);
             }
         });
     }

--- a/app/src/main/java/be/ugent/zeus/hydra/recyclerview/viewholder/sko/LineupViewHolder.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/recyclerview/viewholder/sko/LineupViewHolder.java
@@ -4,7 +4,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Parcelable;
 import android.provider.CalendarContract;
-import android.support.v7.widget.CardView;
 import android.view.ContextMenu;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -40,7 +39,6 @@ public class LineupViewHolder extends DataViewHolder<Artist> implements View.OnC
     private TextView date;
     private ImageView image;
     private Artist artist;
-    private CardView cardView;
 
     public LineupViewHolder(View itemView) {
         super(itemView);

--- a/app/src/main/java/be/ugent/zeus/hydra/utils/DateUtils.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/utils/DateUtils.java
@@ -48,6 +48,10 @@ public class DateUtils {
         }
     }
 
+    public static boolean isThisWeek(LocalDate date) {
+        return Period.between(LocalDate.now(), date).getDays() <= 7;
+    }
+
     /**
      * Convert a date time to a relative string. The precision is one minute, and the resulting string is
      * abbreviated.

--- a/app/src/main/res/layout/home_minerva_agenda_card.xml
+++ b/app/src/main/res/layout/home_minerva_agenda_card.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<android.support.v7.widget.CardView xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:foreground="?android:attr/selectableItemBackground"
+    android:layout_marginBottom="@dimen/card_spacing"
+    android:clickable="true">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+
+        <be.ugent.zeus.hydra.views.NowToolbar
+            android:id="@+id/card_now_toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:icon="@drawable/ic_tabs_minerva"
+            app:title="Les van Minerva"
+            />
+
+        <LinearLayout
+            android:paddingRight="@dimen/card_title_padding_vertical"
+            android:paddingLeft="@dimen/card_title_padding_vertical"
+            android:paddingBottom="@dimen/card_title_padding_bottom_no_content"
+            android:orientation="vertical"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:id="@+id/title"
+                android:ellipsize="end"
+                style="@style/Base.TextAppearance.AppCompat.Title"
+                tools:text="Titel van het evenement die zeer lang is!" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:id="@+id/location"
+                android:textColor="?android:attr/textColorSecondary"
+                tools:text="Locatie van het vak" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:id="@+id/date"
+                android:singleLine="true"
+                tools:text="Datum en tijd" />
+
+        </LinearLayout>
+    </LinearLayout>
+
+</android.support.v7.widget.CardView>

--- a/app/src/main/res/layout/home_minerva_agenda_card.xml
+++ b/app/src/main/res/layout/home_minerva_agenda_card.xml
@@ -4,7 +4,6 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    xmlns:tools="http://schemas.android.com/tools"
     android:foreground="?android:attr/selectableItemBackground"
     android:layout_marginBottom="@dimen/card_spacing"
     android:clickable="true">
@@ -19,40 +18,19 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             app:icon="@drawable/ic_tabs_minerva"
-            app:title="Les van Minerva"
             />
 
         <LinearLayout
             android:paddingRight="@dimen/card_title_padding_vertical"
             android:paddingLeft="@dimen/card_title_padding_vertical"
-            android:paddingBottom="@dimen/card_title_padding_bottom_no_content"
+            android:paddingBottom="@dimen/card_text_padding_bottom"
             android:orientation="vertical"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content">
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:id="@+id/title"
-                android:ellipsize="end"
-                style="@style/Base.TextAppearance.AppCompat.Title"
-                tools:text="Titel van het evenement die zeer lang is!" />
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:id="@+id/location"
-                android:textColor="?android:attr/textColorSecondary"
-                tools:text="Locatie van het vak" />
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:id="@+id/date"
-                android:singleLine="true"
-                tools:text="Datum en tijd" />
+            android:layout_height="wrap_content"
+            android:id="@+id/linear_layout">
 
         </LinearLayout>
+
     </LinearLayout>
 
 </android.support.v7.widget.CardView>

--- a/app/src/main/res/layout/home_minerva_announcement_card.xml
+++ b/app/src/main/res/layout/home_minerva_announcement_card.xml
@@ -18,7 +18,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             app:icon="@drawable/ic_tabs_minerva"
-            app:title="Nieuwe aankodiging minerva"
+            app:title="Nieuwe aankondiging minerva"
             />
 
         <LinearLayout

--- a/app/src/main/res/layout/item_minerva_home_agenda.xml
+++ b/app/src/main/res/layout/item_minerva_home_agenda.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/parent_layout"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:paddingTop="@dimen/list_dense_two_line_padding_horizontal"
+    android:paddingBottom="@dimen/list_dense_two_line_padding_horizontal"
+    android:orientation="vertical"
+    android:gravity="center_vertical"
+    android:background="?android:attr/selectableItemBackground"
+    android:clickable="true">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textAppearance="@style/TextAppearance.AppCompat.Title"
+        android:textSize="@dimen/list_dense_two_line_primary_text_size"
+        android:id="@+id/title"
+        tools:text="Titel" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textSize="@dimen/list_dense_two_line_secondary_text_size"
+        android:id="@+id/subtitle"
+        tools:text="Lesgever + code" />
+
+</LinearLayout>

--- a/app/src/main/res/values/array.xml
+++ b/app/src/main/res/values/array.xml
@@ -36,6 +36,7 @@
         <item>4</item>
         <item>5</item>
         <item>7</item>
+        <item>8</item>
     </string-array>
 
     <string-array name="card_types_names">
@@ -44,6 +45,7 @@
         <item>Schamperartikel</item>
         <item>Nieuwsitem</item>
         <item>Minerva-aankondigingen</item>
+        <item>Minerva-agenda</item>
     </string-array>
 
     <string-array name="minerva_frequencies_text">


### PR DESCRIPTION
Add the Minerva agenda items to the home feed.

When the Minerva API returns Centauro things as well, we should evaluate if putting every agenda item for the next month in the home feed doesn't clutter it too much.

Note: git merging caused the two commits with the same name.