### PR TITLE
Unjack

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -73,7 +73,7 @@ project.afterEvaluate {
 }
 
 //The support library version
-final SUPPORT_LIBRARY_VERSION = '25.0.1'
+final SUPPORT_LIBRARY_VERSION = '25.1.0'
 
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.android.application'
 //Enable this when disabling jack
-//apply plugin: 'me.tatarka.retrolambda'
+apply plugin: 'me.tatarka.retrolambda'
 apply plugin: 'com.cookpad.android.licensetools'
 
 android {
@@ -17,9 +17,9 @@ android {
         
         //Enable jack support
         //When disabling jack, DON'T forget to enable retrolambda
-        jackOptions {
-            enabled true
-        }
+//        jackOptions {
+//            enabled true
+//        }
 
         //Load the API keys from the file "secrets.properties".
         Properties props = new Properties()

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
         classpath 'com.cookpad.android.licensetools:license-tools-plugin:0.17.0'
 
         //When disabling jack, uncomment this
-        //classpath 'me.tatarka:gradle-retrolambda:3.4.0'
+        classpath 'me.tatarka:gradle-retrolambda:3.4.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/firebasenoop/build.gradle
+++ b/firebasenoop/build.gradle
@@ -3,10 +3,18 @@ apply plugin: 'com.android.library'
 android {
     compileSdkVersion 25
     buildToolsVersion "25.0.2"
+
+    defaultConfig {
+        minSdkVersion 9
+        versionName "10.0.1"
+        versionCode 1001
+    }
 }
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
 
-    compile 'com.google.firebase:firebase-core:10.0.1'
+    compile ('com.google.firebase:firebase-core:10.0.1') {
+        exclude module:'support-v4'
+    }
 }


### PR DESCRIPTION
The Jack compiler causes quite a few issues and longer build times and is thus less ready for production than I thought. I have reverted the use of Jack whilst keeping support for lambda's and method references.

Also update the Support Libraries to 25.1.0 (this was not possible using Jack)