### PR TITLE
Fix wrong time on events

### DIFF
--- a/app/src/main/java/be/ugent/zeus/hydra/activities/EventDetailActivity.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/activities/EventDetailActivity.java
@@ -96,8 +96,8 @@ public class EventDetailActivity extends HydraActivity {
         TextView startTime = $(R.id.time_start);
         TextView endTime = $(R.id.time_end);
 
-        startTime.setText(event.getStart().format(format));
-        endTime.setText(event.getEnd().format(format));
+        startTime.setText(event.getLocalStart().format(format));
+        endTime.setText(event.getLocalEnd().format(format));
 
         if (event.getAssociation() != null && event.getAssociation().getImageLink() != null) {
             Picasso.with(this).load(event.getAssociation().getImageLink()).into(organisatorImage, new Callback.EmptyCallback() {


### PR DESCRIPTION
On the detail page of the events, the timezone was not applied to the start/end date, causing them to appear in UTC instead of the local time.