### PR TITLE
Bump Android Gradle plugin to version 2.3.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         maven { url "http://dl.bintray.com/melix/thirdparty-apache" }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.0'
         classpath 'com.google.gms:google-services:3.0.0'
         classpath 'com.cookpad.android.licensetools:license-tools-plugin:0.19.1'
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         maven { url "http://dl.bintray.com/melix/thirdparty-apache" }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0'
+        classpath 'com.android.tools.build:gradle:2.3.1'
         classpath 'com.google.gms:google-services:3.0.0'
         classpath 'com.cookpad.android.licensetools:license-tools-plugin:0.19.1'
 


### PR DESCRIPTION
This version of the Android Gradle plugin uses Gradle 3.3 which brings some speed improvements and new features, but more importantly, enables Instant Run in Android Studio.

See: https://developer.android.com/studio/run/index.html#instant-run