### PR TITLE
Minerva ordering

### DIFF
--- a/app/src/main/java/be/ugent/zeus/hydra/data/database/minerva/AgendaDao.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/data/database/minerva/AgendaDao.java
@@ -215,7 +215,8 @@ public class AgendaDao extends Dao implements DiffDao<AgendaItem, Integer> {
                 CourseTable.TABLE_NAME + "." + CourseTable.Columns.TUTOR + " AS " + courseTable + CourseTable.Columns.TUTOR,
                 CourseTable.TABLE_NAME + "." + CourseTable.Columns.STUDENT + " AS " + courseTable + CourseTable.Columns.STUDENT,
                 CourseTable.TABLE_NAME + "." + CourseTable.Columns.ACADEMIC_YEAR + " AS " + courseTable + CourseTable.Columns.ACADEMIC_YEAR,
-        };
+                CourseTable.TABLE_NAME + "." + CourseTable.Columns.ORDER + " AS " + courseTable + CourseTable.Columns.ORDER,
+    };
 
         String now = String.valueOf(instant.toEpochMilli());
         String selection = "(" + AgendaTable.Columns.START_DATE + " >= ? OR " + AgendaTable.Columns.END_DATE + ">= ?)";
@@ -253,6 +254,7 @@ public class AgendaDao extends Dao implements DiffDao<AgendaItem, Integer> {
                 .columnTutor(courseTable + CourseTable.Columns.TUTOR)
                 .columnStudent(courseTable + CourseTable.Columns.STUDENT)
                 .columnYear(courseTable + CourseTable.Columns.ACADEMIC_YEAR)
+                .columnOrder(courseTable + CourseTable.Columns.ORDER)
                 .build();
 
         AgendaExtractor aExtractor = new AgendaExtractor.Builder(c).defaults().build();
@@ -371,6 +373,7 @@ public class AgendaDao extends Dao implements DiffDao<AgendaItem, Integer> {
                 CourseTable.TABLE_NAME + "." + CourseTable.Columns.TUTOR + " AS " + courseTable + CourseTable.Columns.TUTOR,
                 CourseTable.TABLE_NAME + "." + CourseTable.Columns.STUDENT + " AS " + courseTable + CourseTable.Columns.STUDENT,
                 CourseTable.TABLE_NAME + "." + CourseTable.Columns.ACADEMIC_YEAR + " AS " + courseTable + CourseTable.Columns.ACADEMIC_YEAR,
+                CourseTable.TABLE_NAME + "." + CourseTable.Columns.ORDER + " AS " + courseTable + CourseTable.Columns.ORDER,
         };
 
         Cursor c = builder.query(
@@ -395,6 +398,7 @@ public class AgendaDao extends Dao implements DiffDao<AgendaItem, Integer> {
                 .columnTutor(courseTable + CourseTable.Columns.TUTOR)
                 .columnStudent(courseTable + CourseTable.Columns.STUDENT)
                 .columnYear(courseTable + CourseTable.Columns.ACADEMIC_YEAR)
+                .columnOrder(courseTable + CourseTable.Columns.ORDER)
                 .build();
 
         AgendaExtractor aExtractor = new AgendaExtractor.Builder(c).defaults().build();

--- a/app/src/main/java/be/ugent/zeus/hydra/data/database/minerva/AnnouncementDao.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/data/database/minerva/AnnouncementDao.java
@@ -219,6 +219,7 @@ public class AnnouncementDao extends Dao implements DiffDao<Announcement, Intege
                 CourseTable.TABLE_NAME + "." + CourseTable.Columns.TUTOR + " AS " + courseTable + CourseTable.Columns.TUTOR,
                 CourseTable.TABLE_NAME + "." + CourseTable.Columns.STUDENT + " AS " + courseTable + CourseTable.Columns.STUDENT,
                 CourseTable.TABLE_NAME + "." + CourseTable.Columns.ACADEMIC_YEAR + " AS " + courseTable + CourseTable.Columns.ACADEMIC_YEAR,
+                CourseTable.TABLE_NAME + "." + CourseTable.Columns.ORDER + " AS " + courseTable + CourseTable.Columns.ORDER,
         };
 
         Cursor c = builder.query(
@@ -245,6 +246,7 @@ public class AnnouncementDao extends Dao implements DiffDao<Announcement, Intege
                 .columnTutor(courseTable + CourseTable.Columns.TUTOR)
                 .columnStudent(courseTable + CourseTable.Columns.STUDENT)
                 .columnYear(courseTable + CourseTable.Columns.ACADEMIC_YEAR)
+                .columnOrder(courseTable + CourseTable.Columns.ORDER)
                 .build();
         AnnouncementExtractor aExtractor = new AnnouncementExtractor.Builder(c).defaults().build();
 

--- a/app/src/main/java/be/ugent/zeus/hydra/data/database/minerva/CourseDao.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/data/database/minerva/CourseDao.java
@@ -160,25 +160,6 @@ public class CourseDao extends Dao implements DiffDao<Course, String> {
     }
 
     /**
-     * Update a course. This should not be called on the UI thread.
-     *
-     * @param course The course.
-     */
-    public void update(final Course course) {
-
-        SQLiteDatabase db = helper.getWritableDatabase();
-        ContentValues values = getValues(course);
-        db.update(
-                CourseTable.TABLE_NAME,
-                values,
-                CourseTable.Columns.ID + " = ?",
-                new String[]{String.valueOf(course.getId())}
-        );
-
-        Log.i(TAG, "Updated course " + course.getId());
-    }
-
-    /**
      * Get values for a course.
      *
      * @param course The course.

--- a/app/src/main/java/be/ugent/zeus/hydra/data/database/minerva/CourseDao.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/data/database/minerva/CourseDao.java
@@ -7,7 +7,6 @@ import android.database.SQLException;
 import android.database.sqlite.SQLiteDatabase;
 import android.support.annotation.NonNull;
 import android.util.Log;
-
 import be.ugent.zeus.hydra.data.database.Dao;
 import be.ugent.zeus.hydra.data.database.DiffDao;
 import be.ugent.zeus.hydra.data.database.Utils;
@@ -161,6 +160,25 @@ public class CourseDao extends Dao implements DiffDao<Course, String> {
     }
 
     /**
+     * Update a course. This should not be called on the UI thread.
+     *
+     * @param course The course.
+     */
+    public void update(final Course course) {
+
+        SQLiteDatabase db = helper.getWritableDatabase();
+        ContentValues values = getValues(course);
+        db.update(
+                CourseTable.TABLE_NAME,
+                values,
+                CourseTable.Columns.ID + " = ?",
+                new String[]{String.valueOf(course.getId())}
+        );
+
+        Log.i(TAG, "Updated course " + course.getId());
+    }
+
+    /**
      * Get values for a course.
      *
      * @param course The course.
@@ -177,6 +195,7 @@ public class CourseDao extends Dao implements DiffDao<Course, String> {
         values.put(CourseTable.Columns.TUTOR, course.getTutorName());
         values.put(CourseTable.Columns.STUDENT, course.getStudent());
         values.put(CourseTable.Columns.ACADEMIC_YEAR, course.getAcademicYear());
+        values.put(CourseTable.Columns.ORDER, course.getOrder());
 
         return values;
     }
@@ -262,7 +281,7 @@ public class CourseDao extends Dao implements DiffDao<Course, String> {
                 null,
                 null,
                 null,
-                CourseTable.Columns.TITLE);
+                CourseTable.Columns.ORDER + " ASC, " + CourseTable.Columns.TITLE + " ASC");
 
         //If the cursor is null, abort
         if (c == null) {

--- a/app/src/main/java/be/ugent/zeus/hydra/data/database/minerva/CourseExtractor.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/data/database/minerva/CourseExtractor.java
@@ -24,6 +24,7 @@ class CourseExtractor {
     private int columnTutor;
     private int columnStudent;
     private int columnYear;
+    private int columnOrder;
 
     private final Cursor cursor;
 
@@ -45,6 +46,7 @@ class CourseExtractor {
         course.setTutorName(cursor.getString(columnTutor));
         course.setStudent(cursor.getString(columnStudent));
         course.setAcademicYear(cursor.getInt(columnYear));
+        course.setOrder(cursor.getInt(columnOrder));
 
         return course;
     }
@@ -77,6 +79,10 @@ class CourseExtractor {
         return columnYear;
     }
 
+    public int getColumnOrder() {
+        return columnOrder;
+    }
+
     /**
      * Builder class.
      */
@@ -104,6 +110,7 @@ class CourseExtractor {
             extractor.columnTutor = extractor.cursor.getColumnIndexOrThrow(CourseTable.Columns.TUTOR);
             extractor.columnStudent = extractor.cursor.getColumnIndexOrThrow(CourseTable.Columns.STUDENT);
             extractor.columnYear = extractor.cursor.getColumnIndexOrThrow(CourseTable.Columns.ACADEMIC_YEAR);
+            extractor.columnOrder = extractor.cursor.getColumnIndexOrThrow(CourseTable.Columns.ORDER);
 
             return this;
         }
@@ -144,6 +151,11 @@ class CourseExtractor {
 
         public Builder columnYear(String columnYear) {
             extractor.columnYear = extract(columnYear);
+            return this;
+        }
+
+        public Builder columnOrder(String columnOrder) {
+            extractor.columnOrder = extract(columnOrder);
             return this;
         }
 

--- a/app/src/main/java/be/ugent/zeus/hydra/data/database/minerva/CourseTable.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/data/database/minerva/CourseTable.java
@@ -24,6 +24,7 @@ public final class CourseTable {
         String TUTOR = "tutor";
         String STUDENT = "student";
         String ACADEMIC_YEAR = "academic_year";
+        String ORDER = "ordering";
     }
 
     /**
@@ -37,6 +38,7 @@ public final class CourseTable {
         Column tutor = new Column(Columns.TUTOR, ColumnType.TEXT);
         Column student = new Column(Columns.STUDENT, ColumnType.TEXT);
         Column year = new Column(Columns.ACADEMIC_YEAR, ColumnType.INTEGER);
+        Column order = new Column(Columns.ORDER, ColumnType.INTEGER, ColumnConstraint.NOT_NULL, "0");
 
         return SQLiteQueryBuilder.create().table(TABLE_NAME)
                 .column(id)
@@ -46,6 +48,7 @@ public final class CourseTable {
                 .column(tutor)
                 .column(student)
                 .column(year)
+                .column(order)
                 .build();
     }
 

--- a/app/src/main/java/be/ugent/zeus/hydra/data/database/minerva/DatabaseBroadcaster.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/data/database/minerva/DatabaseBroadcaster.java
@@ -20,7 +20,7 @@ public class DatabaseBroadcaster {
     /**
      * Broadcast when an announcement is updated in any way.
      */
-    public final static String MINERVA_ANNOUNCEMENT_UPDATED = "be.ugent.zeus.hydra.minerva.db.course.update";
+    public final static String MINERVA_ANNOUNCEMENT_UPDATED = "be.ugent.zeus.hydra.minerva.db.announcement.update";
 
     /**
      * The ID of the updated announcement. Used by {@link #MINERVA_ANNOUNCEMENT_UPDATED}. This is an integer.

--- a/app/src/main/java/be/ugent/zeus/hydra/data/database/minerva/DatabaseHelper.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/data/database/minerva/DatabaseHelper.java
@@ -125,7 +125,5 @@ public class DatabaseHelper extends SQLiteOpenHelper {
     private void upgradeFrom7to8(SQLiteDatabase db) {
         // Add the column
         db.execSQL("ALTER TABLE " + CourseTable.TABLE_NAME + " ADD COLUMN " + CourseTable.Columns.ORDER + " INTEGER NOT NULL DEFAULT 0");
-        // Add data
-        db.execSQL("");
     }
 }

--- a/app/src/main/java/be/ugent/zeus/hydra/data/database/minerva/DatabaseHelper.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/data/database/minerva/DatabaseHelper.java
@@ -8,6 +8,7 @@ import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
+import android.util.Log;
 import be.ugent.zeus.hydra.ui.preferences.MinervaFragment;
 import be.ugent.zeus.hydra.data.auth.AccountUtils;
 import be.ugent.zeus.hydra.data.auth.MinervaConfig;
@@ -24,7 +25,7 @@ public class DatabaseHelper extends SQLiteOpenHelper {
     private static final String TAG = "DatabaseHelper";
 
     private static final String NAME = "minervaDatabase.db";
-    private static final int VERSION = 7;
+    private static final int VERSION = 8;
 
     //Singleton - can we avoid this? Should we? I don't know.
     private static DatabaseHelper instance;
@@ -55,15 +56,26 @@ public class DatabaseHelper extends SQLiteOpenHelper {
 
     @Override
     public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
+
+        if (oldVersion != newVersion) {
+            Log.i(TAG, "Upgrading database from " + oldVersion + " to " + newVersion);
+        }
+
         if (oldVersion < 7) {
             upgradeFrom6to7(db);
+        }
+        if (oldVersion < 8) {
+            upgradeFrom7to8(db);
         }
     }
 
     @Override
     public void onDowngrade(SQLiteDatabase db, int oldVersion, int newVersion) {
+        // Manually use table name, since the code might not be available.
+        if (oldVersion >= 8) {
+            db.execSQL("ALTER TABLE " + CourseTable.TABLE_NAME + " DROP COLUMN ordering");
+        }
         if (oldVersion >= 7) {
-            // Manually use table name, since the code might not be available.
             db.execSQL("ALTER TABLE " + AgendaTable.TABLE_NAME + " DROP COLUMN calendar_id");
         }
     }
@@ -108,5 +120,12 @@ public class DatabaseHelper extends SQLiteOpenHelper {
             bundle.putBoolean(Adapter.EXTRA_SCHEDULE_AGENDA, true);
             SyncUtils.requestSync(account, MinervaConfig.COURSE_AUTHORITY, bundle);
         }
+    }
+
+    private void upgradeFrom7to8(SQLiteDatabase db) {
+        // Add the column
+        db.execSQL("ALTER TABLE " + CourseTable.TABLE_NAME + " ADD COLUMN " + CourseTable.Columns.ORDER + " INTEGER NOT NULL DEFAULT 0");
+        // Add data
+        db.execSQL("");
     }
 }

--- a/app/src/main/java/be/ugent/zeus/hydra/data/models/minerva/Course.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/data/models/minerva/Course.java
@@ -22,6 +22,8 @@ public final class Course implements Serializable, Parcelable {
     @SerializedName("academic_year")
     private int academicYear;
 
+    private int order;
+
     public String getId() {
         return id;
     }
@@ -92,6 +94,7 @@ public final class Course implements Serializable, Parcelable {
         dest.writeString(this.tutorName);
         dest.writeString(this.student);
         dest.writeInt(this.academicYear);
+        dest.writeInt(this.order);
     }
 
     public Course() {
@@ -105,6 +108,7 @@ public final class Course implements Serializable, Parcelable {
         this.tutorName = in.readString();
         this.student = in.readString();
         this.academicYear = in.readInt();
+        this.order = in.readInt();
     }
 
     public static final Parcelable.Creator<Course> CREATOR = new Parcelable.Creator<Course>() {
@@ -130,5 +134,13 @@ public final class Course implements Serializable, Parcelable {
     @Override
     public int hashCode() {
         return java8.util.Objects.hash(id);
+    }
+
+    public int getOrder() {
+        return order;
+    }
+
+    public void setOrder(int order) {
+        this.order = order;
     }
 }

--- a/app/src/main/java/be/ugent/zeus/hydra/ui/common/BaseActivity.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/ui/common/BaseActivity.java
@@ -100,7 +100,7 @@ public abstract class BaseActivity extends PluginActivity {
      * @param ids  The ids of the icon.
      */
     public static void tintToolbarIcons(ActionBar toolbar, Menu menu, int... ids) {
-        int color = ViewUtils.getColor(toolbar.getThemedContext(), android.R.attr.textColorPrimary);
+        int color = ViewUtils.getColor(toolbar.getThemedContext(), R.attr.colorControlNormal);
         for (int id : ids) {
             Drawable drawable = DrawableCompat.wrap(menu.findItem(id).getIcon());
             DrawableCompat.setTint(drawable, color);

--- a/app/src/main/java/be/ugent/zeus/hydra/ui/common/recyclerview/adapters/DiffSearchableItemAdapter.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/ui/common/recyclerview/adapters/DiffSearchableItemAdapter.java
@@ -14,10 +14,12 @@ import java.util.List;
  *
  * @author Niko Strijbol
  */
-public abstract class DiffSearchableItemAdapter<D, V extends DataViewHolder<D>> extends ItemDiffAdapter<D, V> implements SearchView.OnQueryTextListener {
+public abstract class DiffSearchableItemAdapter<D, V extends DataViewHolder<D>> extends ItemDiffAdapter<D, V> implements SearchView.OnQueryTextListener, SearchView.OnCloseListener {
 
     private List<D> allData;
     private final Function<D, String> stringifier;
+
+    private boolean isSearching;
 
     protected DiffSearchableItemAdapter(Function<D, String> stringifier) {
         this.stringifier = stringifier;
@@ -36,6 +38,7 @@ public abstract class DiffSearchableItemAdapter<D, V extends DataViewHolder<D>> 
 
     @Override
     public boolean onQueryTextChange(String newText) {
+        this.isSearching = true;
         List<D> filtered = StreamSupport.stream(allData)
                 .filter(s -> stringifier.apply(s).contains(newText.toLowerCase()))
                 .collect(Collectors.toList());
@@ -50,5 +53,18 @@ public abstract class DiffSearchableItemAdapter<D, V extends DataViewHolder<D>> 
             updateItemInternal(items);
             isDiffing = true;
         }
+    }
+
+    @Override
+    public boolean onClose() {
+        this.isSearching = false;
+        return false;
+    }
+
+    /**
+     * @return True if search is active, i.e. the results are filtered by the search.
+     */
+    protected boolean isSearching() {
+        return isSearching;
     }
 }

--- a/app/src/main/java/be/ugent/zeus/hydra/ui/common/recyclerview/adapters/EmptyItemAdapter.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/ui/common/recyclerview/adapters/EmptyItemAdapter.java
@@ -1,13 +1,14 @@
 package be.ugent.zeus.hydra.ui.common.recyclerview.adapters;
 
 import android.support.annotation.LayoutRes;
+import android.support.annotation.Nullable;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-
 import be.ugent.zeus.hydra.ui.common.recyclerview.viewholders.DataViewHolder;
 import be.ugent.zeus.hydra.ui.common.recyclerview.viewholders.SimpleViewHolder;
+import su.j2e.rvjoiner.RvJoiner;
 
 /**
  * Extension of {@link ItemAdapter} that shows a specified view when there are no items.
@@ -20,11 +21,14 @@ public abstract class EmptyItemAdapter<E, V extends DataViewHolder<E>> extends A
 
     public static final int EMPTY_TYPE = 1;
 
+    private RvJoiner rvJoiner;
+
     @LayoutRes
     private int emptyViewId;
 
-    public EmptyItemAdapter(@LayoutRes int emptyViewId) {
+    public EmptyItemAdapter(@LayoutRes int emptyViewId, @Nullable RvJoiner rvJoiner) {
         this.emptyViewId = emptyViewId;
+        this.rvJoiner = rvJoiner;
     }
 
     /**
@@ -61,9 +65,18 @@ public abstract class EmptyItemAdapter<E, V extends DataViewHolder<E>> extends A
      */
     @Override
     public void onBindViewHolder(RecyclerView.ViewHolder holder, int position) {
-        // We use instance of here instead of getItemType(), because this makes it easy to work with RvJoiner.
-        if (holder instanceof DataViewHolder) {
-            @SuppressWarnings("unchecked")
+
+        int type;
+        if (rvJoiner != null) {
+            // If we are using RvJoiner, we must get the real type, not the joined one.
+            // See the repository for more information.
+            type = rvJoiner.getPositionInfo(holder.getAdapterPosition()).realType;
+        } else {
+            type = holder.getItemViewType();
+        }
+
+        if (type != EMPTY_TYPE && holder instanceof DataViewHolder) {
+            @SuppressWarnings("unchecked") // For the generics
             DataViewHolder<E> viewHolder = (DataViewHolder<E>) holder;
             viewHolder.populate(items.get(position));
         }

--- a/app/src/main/java/be/ugent/zeus/hydra/ui/common/recyclerview/ordering/DragCallback.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/ui/common/recyclerview/ordering/DragCallback.java
@@ -1,0 +1,39 @@
+package be.ugent.zeus.hydra.ui.common.recyclerview.ordering;
+
+import android.support.v7.widget.RecyclerView;
+import android.support.v7.widget.helper.ItemTouchHelper;
+import android.util.Log;
+
+/**
+ * @author Niko Strijbol
+ */
+public class DragCallback extends ItemTouchHelper.SimpleCallback {
+
+    private final ItemDragHelperAdapter adapter;
+
+    public DragCallback(ItemDragHelperAdapter adapter) {
+        super(ItemTouchHelper.DOWN | ItemTouchHelper.UP, 0);
+        this.adapter = adapter;
+    }
+
+    @Override
+    public boolean onMove(RecyclerView recyclerView, RecyclerView.ViewHolder viewHolder, RecyclerView.ViewHolder target) {
+        return adapter.onItemMove(viewHolder.getAdapterPosition(), target.getAdapterPosition());
+    }
+
+    @Override
+    public void onSwiped(RecyclerView.ViewHolder viewHolder, int direction) {
+    }
+
+    @Override
+    public boolean isItemViewSwipeEnabled() {
+        return false;
+    }
+
+    @Override
+    public void clearView(RecyclerView recyclerView, RecyclerView.ViewHolder viewHolder) {
+        super.clearView(recyclerView, viewHolder);
+        Log.d("CLEAR", "cleared!");
+        adapter.onMoveCompleted(viewHolder);
+    }
+}

--- a/app/src/main/java/be/ugent/zeus/hydra/ui/common/recyclerview/ordering/DragCallback.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/ui/common/recyclerview/ordering/DragCallback.java
@@ -31,6 +31,11 @@ public class DragCallback extends ItemTouchHelper.SimpleCallback {
     }
 
     @Override
+    public boolean isLongPressDragEnabled() {
+        return adapter.isLongPressDragEnabled();
+    }
+
+    @Override
     public void clearView(RecyclerView recyclerView, RecyclerView.ViewHolder viewHolder) {
         super.clearView(recyclerView, viewHolder);
         Log.d("CLEAR", "cleared!");

--- a/app/src/main/java/be/ugent/zeus/hydra/ui/common/recyclerview/ordering/DragCallback.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/ui/common/recyclerview/ordering/DragCallback.java
@@ -2,7 +2,6 @@ package be.ugent.zeus.hydra.ui.common.recyclerview.ordering;
 
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.helper.ItemTouchHelper;
-import android.util.Log;
 
 /**
  * @author Niko Strijbol
@@ -38,7 +37,6 @@ public class DragCallback extends ItemTouchHelper.SimpleCallback {
     @Override
     public void clearView(RecyclerView recyclerView, RecyclerView.ViewHolder viewHolder) {
         super.clearView(recyclerView, viewHolder);
-        Log.d("CLEAR", "cleared!");
         adapter.onMoveCompleted(viewHolder);
     }
 }

--- a/app/src/main/java/be/ugent/zeus/hydra/ui/common/recyclerview/ordering/ItemDragHelperAdapter.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/ui/common/recyclerview/ordering/ItemDragHelperAdapter.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2015 Paul Burke
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package be.ugent.zeus.hydra.ui.common.recyclerview.ordering;
+
+import android.support.v7.widget.RecyclerView;
+import android.support.v7.widget.helper.ItemTouchHelper;
+
+/**
+ * Interface to listen for a move or dismissal event from a {@link ItemTouchHelper.Callback}.
+ * This interface only handles dragging, not swiping.
+ *
+ * @author Paul Burke (ipaulpro)
+ * @author Niko Strijbol
+ */
+public interface ItemDragHelperAdapter {
+
+    /**
+     * Called when an item has been dragged far enough to trigger a move. This is called every time
+     * an item is shifted, and <strong>not</strong> at the end of a "drop" event.<br/>
+     * <br/>
+     * Implementations should call {@link RecyclerView.Adapter#notifyItemMoved(int, int)} after
+     * adjusting the underlying data to reflect this move.
+     *
+     * @param fromPosition The start position of the moved item.
+     * @param toPosition   Then resolved position of the moved item.
+     * @return True if the item was moved to the new adapter position.
+     *
+     * @see RecyclerView#getAdapterPositionFor(RecyclerView.ViewHolder)
+     * @see RecyclerView.ViewHolder#getAdapterPosition()
+     */
+    boolean onItemMove(int fromPosition, int toPosition);
+
+    /**
+     * Called when the item has been moved and everything is finished.
+     *
+     * @param viewHolder The moved view holder.
+     *
+     * @see ItemTouchHelper.Callback#clearView(RecyclerView, RecyclerView.ViewHolder)
+     */
+    void onMoveCompleted(RecyclerView.ViewHolder viewHolder);
+}

--- a/app/src/main/java/be/ugent/zeus/hydra/ui/common/recyclerview/ordering/ItemDragHelperAdapter.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/ui/common/recyclerview/ordering/ItemDragHelperAdapter.java
@@ -51,4 +51,13 @@ public interface ItemDragHelperAdapter {
      * @see ItemTouchHelper.Callback#clearView(RecyclerView, RecyclerView.ViewHolder)
      */
     void onMoveCompleted(RecyclerView.ViewHolder viewHolder);
+
+    /**
+     * Enables the adapter to temporarily disable dragging by long pressing.
+     *
+     * @return True if long pressing is enabled.
+     *
+     * @see ItemTouchHelper.Callback#isLongPressDragEnabled()
+     */
+    boolean isLongPressDragEnabled();
 }

--- a/app/src/main/java/be/ugent/zeus/hydra/ui/common/recyclerview/ordering/OnStartDragListener.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/ui/common/recyclerview/ordering/OnStartDragListener.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2015 Paul Burke
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package be.ugent.zeus.hydra.ui.common.recyclerview.ordering;
+
+
+import android.support.v7.widget.RecyclerView;
+
+/**
+ * Listener for manual initiation of a drag.
+ */
+public interface OnStartDragListener {
+
+    /**
+     * Called when a view is requesting a start of a drag.
+     *
+     * @param viewHolder The holder of the view to drag.
+     */
+    void onStartDrag(RecyclerView.ViewHolder viewHolder);
+
+}

--- a/app/src/main/java/be/ugent/zeus/hydra/ui/main/LibraryListAdapter.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/ui/main/LibraryListAdapter.java
@@ -5,6 +5,7 @@ import android.view.ViewGroup;
 import be.ugent.zeus.hydra.R;
 import be.ugent.zeus.hydra.data.models.library.Library;
 import be.ugent.zeus.hydra.ui.common.recyclerview.adapters.EmptyItemAdapter;
+import su.j2e.rvjoiner.RvJoiner;
 
 /**
  * Adapter for a list of libraries, with support for showing a message when there are no libraries.
@@ -13,8 +14,8 @@ import be.ugent.zeus.hydra.ui.common.recyclerview.adapters.EmptyItemAdapter;
  */
 class LibraryListAdapter extends EmptyItemAdapter<Library, LibraryViewHolder> {
 
-    LibraryListAdapter() {
-        super(R.layout.item_no_data);
+    LibraryListAdapter(RvJoiner rvJoiner) {
+        super(R.layout.item_no_data, rvJoiner);
     }
 
     @Override

--- a/app/src/main/java/be/ugent/zeus/hydra/ui/main/LibraryListFragment.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/ui/main/LibraryListFragment.java
@@ -37,8 +37,8 @@ public class LibraryListFragment extends PluginFragment {
     public static final String PREF_LIBRARY_FAVOURITES = "pref_library_favourites";
 
     private final RvJoiner joiner = new RvJoiner();
-    private final LibraryListAdapter favourites = new LibraryListAdapter();
-    private final LibraryListAdapter all = new LibraryListAdapter();
+    private final LibraryListAdapter favourites = new LibraryListAdapter(joiner);
+    private final LibraryListAdapter all = new LibraryListAdapter(joiner);
     private final RequestPlugin<Pair<List<Library>, List<Library>>> plugin =
             new RequestPlugin<>((Function<Boolean, LoaderCallback<Pair<List<Library>, List<Library>>>>) b -> args -> new LibraryLoader(getContext(), b));
 

--- a/app/src/main/java/be/ugent/zeus/hydra/ui/main/MinervaCourseAdapter.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/ui/main/MinervaCourseAdapter.java
@@ -66,4 +66,9 @@ class MinervaCourseAdapter extends DiffSearchableItemAdapter<Course, MinervaCour
         });
         Log.d("OK", "onMoveCompleted: move complete to " + viewHolder.getAdapterPosition());
     }
+
+    @Override
+    public boolean isLongPressDragEnabled() {
+        return !isSearching();
+    }
 }

--- a/app/src/main/java/be/ugent/zeus/hydra/ui/main/MinervaCourseAdapter.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/ui/main/MinervaCourseAdapter.java
@@ -2,7 +2,6 @@ package be.ugent.zeus.hydra.ui.main;
 
 import android.os.AsyncTask;
 import android.support.v7.widget.RecyclerView;
-import android.util.Log;
 import android.view.ViewGroup;
 import be.ugent.zeus.hydra.R;
 import be.ugent.zeus.hydra.data.database.minerva.CourseDao;
@@ -45,7 +44,6 @@ class MinervaCourseAdapter extends DiffSearchableItemAdapter<Course, MinervaCour
     public boolean onItemMove(int fromPosition, int toPosition) {
         Collections.swap(items, fromPosition, toPosition);
         notifyItemMoved(fromPosition, toPosition);
-        Log.d("OK", "onItemMove: moved from " + fromPosition + " to " + toPosition);
         return true;
     }
 
@@ -64,7 +62,6 @@ class MinervaCourseAdapter extends DiffSearchableItemAdapter<Course, MinervaCour
                     .collect(Collectors.toList());
             courseDao.update(courses);
         });
-        Log.d("OK", "onMoveCompleted: move complete to " + viewHolder.getAdapterPosition());
     }
 
     @Override

--- a/app/src/main/java/be/ugent/zeus/hydra/ui/main/MinervaCourseAdapter.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/ui/main/MinervaCourseAdapter.java
@@ -9,6 +9,7 @@ import be.ugent.zeus.hydra.data.models.minerva.Course;
 import be.ugent.zeus.hydra.ui.common.ViewUtils;
 import be.ugent.zeus.hydra.ui.common.recyclerview.adapters.DiffSearchableItemAdapter;
 import be.ugent.zeus.hydra.ui.common.recyclerview.ordering.ItemDragHelperAdapter;
+import be.ugent.zeus.hydra.ui.common.recyclerview.ordering.OnStartDragListener;
 import java8.util.stream.Collectors;
 import java8.util.stream.IntStreams;
 
@@ -23,9 +24,11 @@ import java.util.Collections;
 class MinervaCourseAdapter extends DiffSearchableItemAdapter<Course, MinervaCourseViewHolder> implements ItemDragHelperAdapter {
 
     private CourseDao courseDao;
+    private final OnStartDragListener startDragListener;
 
-    MinervaCourseAdapter() {
+    MinervaCourseAdapter(OnStartDragListener startDragListener) {
         super(c -> c.getTitle().toLowerCase());
+        this.startDragListener = startDragListener;
     }
 
     /**
@@ -37,7 +40,7 @@ class MinervaCourseAdapter extends DiffSearchableItemAdapter<Course, MinervaCour
 
     @Override
     public MinervaCourseViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
-        return new MinervaCourseViewHolder(ViewUtils.inflate(parent, R.layout.item_minerva_course));
+        return new MinervaCourseViewHolder(ViewUtils.inflate(parent, R.layout.item_minerva_course), startDragListener);
     }
 
     @Override

--- a/app/src/main/java/be/ugent/zeus/hydra/ui/main/MinervaCourseAdapter.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/ui/main/MinervaCourseAdapter.java
@@ -1,25 +1,69 @@
 package be.ugent.zeus.hydra.ui.main;
 
+import android.os.AsyncTask;
+import android.support.v7.widget.RecyclerView;
+import android.util.Log;
 import android.view.ViewGroup;
-
 import be.ugent.zeus.hydra.R;
+import be.ugent.zeus.hydra.data.database.minerva.CourseDao;
 import be.ugent.zeus.hydra.data.models.minerva.Course;
-import be.ugent.zeus.hydra.ui.common.recyclerview.adapters.DiffSearchableItemAdapter;
 import be.ugent.zeus.hydra.ui.common.ViewUtils;
+import be.ugent.zeus.hydra.ui.common.recyclerview.adapters.DiffSearchableItemAdapter;
+import be.ugent.zeus.hydra.ui.common.recyclerview.ordering.ItemDragHelperAdapter;
+import java8.util.stream.Collectors;
+import java8.util.stream.IntStreams;
+
+import java.util.Collection;
+import java.util.Collections;
 
 /**
  * Adapts a list of courses.
  *
  * @author Niko Strijbol
  */
-class MinervaCourseAdapter extends DiffSearchableItemAdapter<Course, MinervaCourseViewHolder> {
+class MinervaCourseAdapter extends DiffSearchableItemAdapter<Course, MinervaCourseViewHolder> implements ItemDragHelperAdapter {
+
+    private CourseDao courseDao;
 
     MinervaCourseAdapter() {
         super(c -> c.getTitle().toLowerCase());
     }
 
+    /**
+     * @param courseDao The course dao.
+     */
+    public void setCourseDao(CourseDao courseDao) {
+        this.courseDao = courseDao;
+    }
+
     @Override
     public MinervaCourseViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
         return new MinervaCourseViewHolder(ViewUtils.inflate(parent, R.layout.item_minerva_course));
+    }
+
+    @Override
+    public boolean onItemMove(int fromPosition, int toPosition) {
+        Collections.swap(items, fromPosition, toPosition);
+        notifyItemMoved(fromPosition, toPosition);
+        Log.d("OK", "onItemMove: moved from " + fromPosition + " to " + toPosition);
+        return true;
+    }
+
+    @Override
+    public void onMoveCompleted(RecyclerView.ViewHolder viewHolder) {
+        if (courseDao == null) {
+            throw new IllegalStateException("The course DAO cannot be null!");
+        }
+        AsyncTask.execute(() -> {
+            Collection<Course> courses = IntStreams.range(0, getItemCount())
+                    .mapToObj(value -> {
+                        Course course1 = items.get(value);
+                        course1.setOrder(value);
+                        return course1;
+                    })
+                    .collect(Collectors.toList());
+            courseDao.update(courses);
+        });
+        Log.d("OK", "onMoveCompleted: move complete to " + viewHolder.getAdapterPosition());
     }
 }

--- a/app/src/main/java/be/ugent/zeus/hydra/ui/main/MinervaCourseViewHolder.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/ui/main/MinervaCourseViewHolder.java
@@ -1,10 +1,14 @@
 package be.ugent.zeus.hydra.ui.main;
 
+import android.support.v4.view.MotionEventCompat;
 import android.support.v7.widget.RecyclerView;
+import android.view.MotionEvent;
 import android.view.View;
+import android.widget.ImageView;
 import android.widget.TextView;
 
 import be.ugent.zeus.hydra.R;
+import be.ugent.zeus.hydra.ui.common.recyclerview.ordering.OnStartDragListener;
 import be.ugent.zeus.hydra.ui.minerva.overview.CourseActivity;
 import be.ugent.zeus.hydra.data.models.minerva.Course;
 import be.ugent.zeus.hydra.ui.common.recyclerview.viewholders.DataViewHolder;
@@ -17,16 +21,22 @@ import static be.ugent.zeus.hydra.ui.common.ViewUtils.$;
  */
 class MinervaCourseViewHolder extends DataViewHolder<Course> {
 
-    private TextView name;
-    private TextView subtitle;
-    private View parent;
+    private final TextView name;
+    private final TextView subtitle;
 
-    MinervaCourseViewHolder(View itemView) {
+    MinervaCourseViewHolder(View itemView, OnStartDragListener listener) {
         super(itemView);
 
         name = $(itemView, R.id.name);
         subtitle = $(itemView, R.id.subtitle);
-        parent = $(itemView, R.id.parent_layout);
+        ImageView dragHandle = $(itemView, R.id.drag_handle);
+        dragHandle.setOnTouchListener((v, event) -> {
+            if (MotionEventCompat.getActionMasked(event) == MotionEvent.ACTION_DOWN) {
+                listener.onStartDrag(MinervaCourseViewHolder.this);
+                return true;
+            }
+            return false;
+        });
     }
 
     /**
@@ -42,6 +52,6 @@ class MinervaCourseViewHolder extends DataViewHolder<Course> {
         subtitle.setText(tutor + " - " + course.getCode());
 
         //Set onclick listener
-        parent.setOnClickListener(view -> CourseActivity.start(view.getContext(), course));
+        itemView.setOnClickListener(view -> CourseActivity.start(view.getContext(), course));
     }
 }

--- a/app/src/main/java/be/ugent/zeus/hydra/ui/main/MinervaFragment.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/ui/main/MinervaFragment.java
@@ -15,6 +15,7 @@ import android.support.v4.content.Loader;
 import android.support.v4.content.LocalBroadcastManager;
 import android.support.v7.widget.DividerItemDecoration;
 import android.support.v7.widget.SearchView;
+import android.support.v7.widget.helper.ItemTouchHelper;
 import android.util.Log;
 import android.view.*;
 import android.widget.Button;
@@ -37,6 +38,7 @@ import be.ugent.zeus.hydra.ui.common.plugins.ProgressBarPlugin;
 import be.ugent.zeus.hydra.ui.common.plugins.RecyclerViewPlugin;
 import be.ugent.zeus.hydra.ui.common.plugins.common.Plugin;
 import be.ugent.zeus.hydra.ui.common.plugins.common.PluginFragment;
+import be.ugent.zeus.hydra.ui.common.recyclerview.ordering.DragCallback;
 
 import java.io.IOException;
 import java.util.List;
@@ -130,6 +132,11 @@ public class MinervaFragment extends PluginFragment implements LoaderCallback<Li
         authWrapper = $(view, R.id.auth_wrapper);
 
         plugin.addItemDecoration(new DividerItemDecoration(getContext(), DividerItemDecoration.VERTICAL));
+
+        adapter.setCourseDao(courseDao);
+        ItemTouchHelper.Callback callback = new DragCallback(adapter);
+        ItemTouchHelper helper = new ItemTouchHelper(callback);
+        helper.attachToRecyclerView(plugin.getRecyclerView());
     }
 
     private boolean isLoggedIn() {

--- a/app/src/main/java/be/ugent/zeus/hydra/ui/main/MinervaFragment.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/ui/main/MinervaFragment.java
@@ -14,6 +14,7 @@ import android.support.design.widget.Snackbar;
 import android.support.v4.content.Loader;
 import android.support.v4.content.LocalBroadcastManager;
 import android.support.v7.widget.DividerItemDecoration;
+import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.SearchView;
 import android.support.v7.widget.helper.ItemTouchHelper;
 import android.util.Log;
@@ -39,6 +40,7 @@ import be.ugent.zeus.hydra.ui.common.plugins.RecyclerViewPlugin;
 import be.ugent.zeus.hydra.ui.common.plugins.common.Plugin;
 import be.ugent.zeus.hydra.ui.common.plugins.common.PluginFragment;
 import be.ugent.zeus.hydra.ui.common.recyclerview.ordering.DragCallback;
+import be.ugent.zeus.hydra.ui.common.recyclerview.ordering.OnStartDragListener;
 
 import java.io.IOException;
 import java.util.List;
@@ -51,7 +53,7 @@ import static be.ugent.zeus.hydra.ui.common.ViewUtils.$;
  * @author silox
  * @author Niko Strijbol
  */
-public class MinervaFragment extends PluginFragment implements LoaderCallback<List<Course>> {
+public class MinervaFragment extends PluginFragment implements LoaderCallback<List<Course>>, OnStartDragListener {
 
     private static final String TAG = "MinervaFragment";
 
@@ -60,9 +62,10 @@ public class MinervaFragment extends PluginFragment implements LoaderCallback<Li
     private View authWrapper;
     private Snackbar syncBar;
 
-    private MinervaCourseAdapter adapter = new MinervaCourseAdapter();
+    private MinervaCourseAdapter adapter = new MinervaCourseAdapter(this);
     private AccountManager manager;
     private CourseDao courseDao;
+    private ItemTouchHelper helper;
 
     private RecyclerViewPlugin<Course> plugin =
             new RecyclerViewPlugin<>(this, adapter);
@@ -135,7 +138,7 @@ public class MinervaFragment extends PluginFragment implements LoaderCallback<Li
 
         adapter.setCourseDao(courseDao);
         ItemTouchHelper.Callback callback = new DragCallback(adapter);
-        ItemTouchHelper helper = new ItemTouchHelper(callback);
+        helper = new ItemTouchHelper(callback);
         helper.attachToRecyclerView(plugin.getRecyclerView());
     }
 
@@ -316,5 +319,10 @@ public class MinervaFragment extends PluginFragment implements LoaderCallback<Li
     @Override
     public Loader<LoaderResult<List<Course>>> getLoader(Bundle args) {
         return new MinervaCoursesLoader(getContext(), courseDao);
+    }
+
+    @Override
+    public void onStartDrag(RecyclerView.ViewHolder viewHolder) {
+        helper.startDrag(viewHolder);
     }
 }

--- a/app/src/main/java/be/ugent/zeus/hydra/ui/main/MinervaFragment.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/ui/main/MinervaFragment.java
@@ -205,6 +205,7 @@ public class MinervaFragment extends PluginFragment implements LoaderCallback<Li
             inflater.inflate(R.menu.menu_minerva, menu);
             SearchView view = (SearchView) menu.findItem(R.id.action_search).getActionView();
             view.setOnQueryTextListener(adapter);
+            view.setOnCloseListener(adapter);
         }
     }
 

--- a/app/src/main/java/be/ugent/zeus/hydra/ui/minerva/overview/AgendaAdapter.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/ui/minerva/overview/AgendaAdapter.java
@@ -17,7 +17,7 @@ class AgendaAdapter extends EmptyItemAdapter<AgendaItem, AgendaViewHolder> imple
     private static final DateTimeFormatter INT_FORMATTER = DateTimeFormatter.ofPattern("ddMMyyyy");
 
     AgendaAdapter() {
-        super(R.layout.item_no_data);
+        super(R.layout.item_no_data, null);
     }
 
     @Override

--- a/app/src/main/java/be/ugent/zeus/hydra/ui/minerva/overview/AnnouncementAdapter.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/ui/minerva/overview/AnnouncementAdapter.java
@@ -14,7 +14,7 @@ import be.ugent.zeus.hydra.ui.common.ViewUtils;
 class AnnouncementAdapter extends EmptyItemAdapter<Announcement, AnnouncementViewHolder> {
 
     AnnouncementAdapter() {
-        super(R.layout.item_no_data);
+        super(R.layout.item_no_data, null);
     }
 
     @Override

--- a/app/src/main/res/drawable/ic_drag_handle.xml
+++ b/app/src/main/res/drawable/ic_drag_handle.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M20,9H4v2h16V9zM4,15h16v-2H4v2z"/>
+</vector>

--- a/app/src/main/res/layout/item_minerva_course.xml
+++ b/app/src/main/res/layout/item_minerva_course.xml
@@ -2,6 +2,7 @@
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/parent_layout"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -37,6 +38,15 @@
             tools:text="Lesgever + code" />
 
     </LinearLayout>
+
+    <ImageView
+        android:id="@+id/drag_handle"
+        android:layout_gravity="end"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:scaleType="center"
+        android:tint="@color/ugent_blue_lighter"
+        app:srcCompat="@drawable/ic_drag_handle" />
 
     <!--<FrameLayout-->
     <!--android:layout_width="wrap_content"-->

--- a/app/src/main/res/layout/item_minerva_course.xml
+++ b/app/src/main/res/layout/item_minerva_course.xml
@@ -5,12 +5,13 @@
     android:id="@+id/parent_layout"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:background="?android:colorBackground"
+    android:foreground="?android:attr/selectableItemBackground"
     android:paddingLeft="@dimen/list_two_line_padding_vertical"
     android:paddingRight="@dimen/list_two_line_padding_vertical"
     android:paddingTop="@dimen/list_two_line_padding_horizontal"
     android:paddingBottom="@dimen/list_two_line_padding_horizontal"
-    android:orientation="horizontal"
-    android:background="?android:attr/selectableItemBackground"
     android:clickable="true"
     android:baselineAligned="false">
 
@@ -38,33 +39,33 @@
     </LinearLayout>
 
     <!--<FrameLayout-->
-        <!--android:layout_width="wrap_content"-->
-        <!--android:layout_height="match_parent">-->
+    <!--android:layout_width="wrap_content"-->
+    <!--android:layout_height="match_parent">-->
 
-        <!--<ImageView-->
-            <!--android:id="@+id/arrow_icon"-->
-            <!--android:layout_width="wrap_content"-->
-            <!--android:layout_height="wrap_content"-->
-            <!--app:srcCompat="@drawable/ic_keyboard_arrow_down"-->
-            <!--android:tint="@color/ugent_blue_dark"-->
-            <!--android:layout_gravity="center_vertical"-->
-            <!--android:visibility="gone"-->
-            <!--tools:ignore="MissingPrefix" />-->
+    <!--<ImageView-->
+    <!--android:id="@+id/arrow_icon"-->
+    <!--android:layout_width="wrap_content"-->
+    <!--android:layout_height="wrap_content"-->
+    <!--app:srcCompat="@drawable/ic_keyboard_arrow_down"-->
+    <!--android:tint="@color/ugent_blue_dark"-->
+    <!--android:layout_gravity="center_vertical"-->
+    <!--android:visibility="gone"-->
+    <!--tools:ignore="MissingPrefix" />-->
 
-        <!--<ImageView-->
-            <!--android:id="@+id/error_icon"-->
-            <!--android:layout_width="wrap_content"-->
-            <!--android:layout_height="wrap_content"-->
-            <!--app:srcCompat="@drawable/ic_error"-->
-            <!--android:tint="@color/ugent_blue_dark"-->
-            <!--android:layout_gravity="center_vertical"-->
-            <!--android:visibility="gone"-->
-            <!--tools:ignore="MissingPrefix" />-->
+    <!--<ImageView-->
+    <!--android:id="@+id/error_icon"-->
+    <!--android:layout_width="wrap_content"-->
+    <!--android:layout_height="wrap_content"-->
+    <!--app:srcCompat="@drawable/ic_error"-->
+    <!--android:tint="@color/ugent_blue_dark"-->
+    <!--android:layout_gravity="center_vertical"-->
+    <!--android:visibility="gone"-->
+    <!--tools:ignore="MissingPrefix" />-->
 
-        <!--<ProgressBar-->
-            <!--android:id="@+id/progress_bar"-->
-            <!--android:layout_width="32dp"-->
-            <!--android:layout_height="32dp" />-->
+    <!--<ProgressBar-->
+    <!--android:id="@+id/progress_bar"-->
+    <!--android:layout_width="32dp"-->
+    <!--android:layout_height="32dp" />-->
 
     <!--</FrameLayout>-->
 


### PR DESCRIPTION
Add functionality to re-order Minerva courses, as requested in #136.
Of course this is only locally; on other devices or after data wipe the ordering is lost. The long term plan should still be to convince the Minerva people to adjust the API, but alas, what can you do?

Screenshot:
![device-2017-04-15-204446](https://cloud.githubusercontent.com/assets/1756811/25066101/f9e298a4-221c-11e7-9f4b-60e64aff566e.png)
