### PR TITLE
Bug fixes

### DIFF
--- a/app/src/main/java/be/ugent/zeus/hydra/service/urgent/MediaManager.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/service/urgent/MediaManager.java
@@ -206,4 +206,8 @@ public class MediaManager implements
     public boolean isPlaying() {
         return state != ERROR && state != END && mediaPlayer.isPlaying();
     }
+
+    public boolean hasMediaPlayer() {
+        return mediaPlayer != null;
+    }
 }

--- a/app/src/main/java/be/ugent/zeus/hydra/service/urgent/MusicService.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/service/urgent/MusicService.java
@@ -261,7 +261,7 @@ public class MusicService extends Service implements MediaStateListener, AudioMa
         AudioManager audioManager = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
         audioManager.abandonAudioFocus(this);
 
-        if (mediaManager != null) {
+        if (mediaManager != null && mediaManager.hasMediaPlayer()) {
             mediaManager.destroy();
         }
 

--- a/app/src/main/java/be/ugent/zeus/hydra/ui/minerva/AuthActivity.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/ui/minerva/AuthActivity.java
@@ -209,6 +209,12 @@ public class AuthActivity extends BaseActivity implements ActivityHelper.Connect
         }
     }
 
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        customTabActivityHelper = null;
+    }
+
     private class InfoTask extends AsyncTask<String, Void, Intent> {
 
         @Override


### PR DESCRIPTION
- Fix null pointer, occurs when the Urgent.fm service was started, but nothing has been played (so the media player is not initialised yet) and the user manually stops the service from the settings.
- Fix memory leak when logging in to Minerva, where the Custom Tab helper would hang on to a reference to the activity after said activity has finished.