### PR TITLE
Handle and log cases where the server returns nothing

### DIFF
--- a/app/src/main/java/be/ugent/zeus/hydra/data/network/JsonSpringRequest.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/data/network/JsonSpringRequest.java
@@ -8,6 +8,7 @@ import be.ugent.zeus.hydra.data.network.exceptions.RestTemplateException;
 import be.ugent.zeus.hydra.repository.requests.Request;
 import be.ugent.zeus.hydra.repository.requests.RequestException;
 import be.ugent.zeus.hydra.repository.requests.Result;
+import com.google.firebase.crash.FirebaseCrash;
 import org.springframework.http.converter.HttpMessageConversionException;
 import org.springframework.http.converter.json.GsonHttpMessageConverter;
 import org.springframework.web.client.ResourceAccessException;
@@ -43,6 +44,12 @@ public abstract class JsonSpringRequest<R> implements Request<R> {
     public Result<R> performRequest(Bundle args) {
         try {
             R result = createRestTemplate().getForEntity(getAPIUrl(), clazz).getBody();
+            if (result == null) {
+                // Create, log and throw exception, since this is not normal.
+                ResourceAccessException exception = new ResourceAccessException("The server did not respond with the expected format for URL: " + getAPIUrl());
+                FirebaseCrash.report(exception);
+                throw exception;
+            }
             return new Result.Builder<R>()
                     .withData(result)
                     .build();


### PR DESCRIPTION
http://student.ugent.be/hydra/api/3.0/recent_news.json currently returns nothing (0 bytes), and this crashed the app. Prevent crashing and log this to Firebase, since this is a server-side error that should be fixed.