### PR TITLE
Fix home feed not using cache

### DIFF
--- a/app/src/main/java/be/ugent/zeus/hydra/repository/requests/Result.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/repository/requests/Result.java
@@ -158,7 +158,7 @@ public class Result<D> {
 
     /**
      * Returns the data if there is no exception. If there is an exception, the exception is thrown, regardless if there
-     * is data present or not.
+     * is data present or not. See {@link #getDataOrThrow()} to get the data if present.
      *
      * @return The data.
      *
@@ -169,6 +169,22 @@ public class Result<D> {
             throw throwable;
         } else {
             return data;
+        }
+    }
+
+    /**
+     * Returns the data if it is present. If there is no data, the exception is thrown. You might also want to use
+     * {@link #getOrThrow()}, which will throw an exception if there is one, regardless if there is data or not.
+     *
+     * @return The data.
+     *
+     * @throws RequestException If there is no data.
+     */
+    public D getDataOrThrow() throws RequestException {
+        if (hasData()) {
+            return data;
+        } else {
+            throw throwable;
         }
     }
 

--- a/app/src/main/java/be/ugent/zeus/hydra/ui/main/homefeed/FeedLiveData.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/ui/main/homefeed/FeedLiveData.java
@@ -12,7 +12,6 @@ import be.ugent.zeus.hydra.BuildConfig;
 import be.ugent.zeus.hydra.data.auth.AccountUtils;
 import be.ugent.zeus.hydra.data.sync.SyncBroadcast;
 import be.ugent.zeus.hydra.repository.data.BaseLiveData;
-import be.ugent.zeus.hydra.repository.requests.RequestException;
 import be.ugent.zeus.hydra.repository.requests.Result;
 import be.ugent.zeus.hydra.ui.main.homefeed.content.HomeCard;
 import be.ugent.zeus.hydra.ui.main.homefeed.content.debug.WaitRequest;
@@ -139,12 +138,14 @@ public class FeedLiveData extends BaseLiveData<Result<List<HomeCard>>> {
     }
 
     private List<HomeCard> executeOperation(@Nullable Bundle args, FeedOperation operation, Set<Integer> errors, List<HomeCard> results) {
-        try {
-            return operation.transform(args, results);
-        } catch (RequestException e) {
+
+        Result<List<HomeCard>> result = operation.transform(args, results);
+
+        if (result.hasException()) {
             errors.add(operation.getCardType());
-            return results;
         }
+
+        return result.orElse(results);
     }
 
     /**

--- a/app/src/main/java/be/ugent/zeus/hydra/ui/main/homefeed/operations/FeedOperation.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/ui/main/homefeed/operations/FeedOperation.java
@@ -1,9 +1,9 @@
 package be.ugent.zeus.hydra.ui.main.homefeed.operations;
 
 import android.os.Bundle;
-import android.support.annotation.AnyThread;
 import android.support.annotation.NonNull;
-import be.ugent.zeus.hydra.repository.requests.RequestException;
+
+import be.ugent.zeus.hydra.repository.requests.Result;
 import be.ugent.zeus.hydra.ui.main.homefeed.content.HomeCard;
 
 import java.util.List;
@@ -26,8 +26,7 @@ public interface FeedOperation {
      * @return The new list, or null on error.
      */
     @NonNull
-    @AnyThread
-    List<HomeCard> transform(Bundle args,  List<HomeCard> current) throws RequestException;
+    Result<List<HomeCard>> transform(Bundle args, List<HomeCard> current);
 
     /**
      * The type of card that will be added/removed by this operation.

--- a/app/src/main/java/be/ugent/zeus/hydra/ui/main/homefeed/operations/RemoveOperation.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/ui/main/homefeed/operations/RemoveOperation.java
@@ -2,8 +2,9 @@ package be.ugent.zeus.hydra.ui.main.homefeed.operations;
 
 import android.os.Bundle;
 import android.support.annotation.NonNull;
+
+import be.ugent.zeus.hydra.repository.requests.Result;
 import be.ugent.zeus.hydra.ui.main.homefeed.content.HomeCard;
-import be.ugent.zeus.hydra.repository.requests.RequestException;
 import java8.util.function.Predicate;
 import java8.util.function.Predicates;
 import java8.util.stream.Collectors;
@@ -33,8 +34,8 @@ class RemoveOperation implements FeedOperation {
 
     @NonNull
     @Override
-    public List<HomeCard> transform(Bundle args, List<HomeCard> current) throws RequestException {
-        return StreamSupport.stream(current).filter(Predicates.negate(predicate)).collect(Collectors.toList());
+    public Result<List<HomeCard>> transform(Bundle args, List<HomeCard> current) {
+        return Result.Builder.fromData(StreamSupport.stream(current).filter(Predicates.negate(predicate)).collect(Collectors.toList()));
     }
 
     @Override

--- a/app/src/main/java/be/ugent/zeus/hydra/ui/main/homefeed/operations/RequestOperation.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/ui/main/homefeed/operations/RequestOperation.java
@@ -2,7 +2,8 @@ package be.ugent.zeus.hydra.ui.main.homefeed.operations;
 
 import android.os.Bundle;
 import android.support.annotation.NonNull;
-import be.ugent.zeus.hydra.repository.requests.RequestException;
+
+import be.ugent.zeus.hydra.repository.requests.Result;
 import be.ugent.zeus.hydra.ui.main.homefeed.HomeFeedRequest;
 import be.ugent.zeus.hydra.ui.main.homefeed.content.HomeCard;
 import java8.util.stream.Collectors;
@@ -34,18 +35,18 @@ class RequestOperation implements FeedOperation {
      * @param current The current cards.
      *
      * @return The updates cards.
-     * @throws RequestException If the request fails.
      */
     @NonNull
     @Override
-    public List<HomeCard> transform(Bundle args, final List<HomeCard> current) throws RequestException {
+    public Result<List<HomeCard>> transform(Bundle args, final List<HomeCard> current) {
 
         // Filter existing cards away.
         Stream<HomeCard> temp = StreamSupport.stream(current)
                 .filter(c -> c.getCardType() != request.getCardType());
 
-        Stream<HomeCard> requestStream = request.performRequest(args).getDataOrThrow();
-        return RefStreams.concat(temp, requestStream).sorted().collect(Collectors.toList());
+        return request.performRequest(args).map(homeCardStream ->
+                RefStreams.concat(temp, homeCardStream).sorted().collect(Collectors.toList())
+        );
     }
 
     @Override

--- a/app/src/main/java/be/ugent/zeus/hydra/ui/main/homefeed/operations/RequestOperation.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/ui/main/homefeed/operations/RequestOperation.java
@@ -44,7 +44,7 @@ class RequestOperation implements FeedOperation {
         Stream<HomeCard> temp = StreamSupport.stream(current)
                 .filter(c -> c.getCardType() != request.getCardType());
 
-        Stream<HomeCard> requestStream = request.performRequest(args).getOrThrow();
+        Stream<HomeCard> requestStream = request.performRequest(args).getDataOrThrow();
         return RefStreams.concat(temp, requestStream).sorted().collect(Collectors.toList());
     }
 


### PR DESCRIPTION
Errors were not properly propagated to the home feed, which means cached data was not used when available if there was no network.