### PR TITLE
Add searching to activities

### DIFF
--- a/app/src/main/java/be/ugent/zeus/hydra/ui/main/events/EventAdapter.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/ui/main/events/EventAdapter.java
@@ -1,11 +1,13 @@
 package be.ugent.zeus.hydra.ui.main.events;
 
+import android.text.TextUtils;
 import android.view.ViewGroup;
 
 import be.ugent.zeus.hydra.R;
+import be.ugent.zeus.hydra.data.models.association.Association;
 import be.ugent.zeus.hydra.data.models.association.Event;
 import be.ugent.zeus.hydra.ui.common.ViewUtils;
-import be.ugent.zeus.hydra.ui.common.recyclerview.adapters.ItemDiffAdapter;
+import be.ugent.zeus.hydra.ui.common.recyclerview.adapters.SearchableDiffAdapter;
 import be.ugent.zeus.hydra.ui.common.recyclerview.viewholders.DateHeaderViewHolder;
 import com.timehop.stickyheadersrecyclerview.StickyRecyclerHeadersAdapter;
 
@@ -15,10 +17,27 @@ import com.timehop.stickyheadersrecyclerview.StickyRecyclerHeadersAdapter;
  * @author ellen
  * @author Niko Strijbol
  */
-class EventAdapter extends ItemDiffAdapter<Event, EventViewHolder> implements StickyRecyclerHeadersAdapter<DateHeaderViewHolder> {
+class EventAdapter extends SearchableDiffAdapter<Event, EventViewHolder> implements StickyRecyclerHeadersAdapter<DateHeaderViewHolder> {
 
     protected EventAdapter() {
-        super();
+        super((event, s) -> {
+            if (!TextUtils.isEmpty(event.getTitle()) && event.getTitle().toLowerCase().contains(s)) {
+                return true;
+            }
+            if (event.getAssociation() != null) {
+                Association association = event.getAssociation();
+                if (!TextUtils.isEmpty(association.getDisplayName()) && association.getDisplayName().toLowerCase().contains(s)) {
+                    return true;
+                }
+                if (!TextUtils.isEmpty(association.getFullName()) && association.getFullName().toLowerCase().contains(s)) {
+                    return true;
+                }
+                if (association.getInternalName().contains(s)) {
+                    return true;
+                }
+            }
+            return false;
+        });
     }
 
     @Override

--- a/app/src/main/java/be/ugent/zeus/hydra/ui/main/events/EventFragment.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/ui/main/events/EventFragment.java
@@ -9,6 +9,7 @@ import android.support.design.widget.Snackbar;
 import android.support.v4.widget.SwipeRefreshLayout;
 import android.support.v7.widget.DividerItemDecoration;
 import android.support.v7.widget.RecyclerView;
+import android.support.v7.widget.SearchView;
 import android.util.Log;
 import android.view.*;
 import android.widget.Button;
@@ -88,10 +89,14 @@ public class EventFragment extends LifecycleFragment {
     @Override
     public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
         super.onCreateOptionsMenu(menu, inflater);
-        inflater.inflate(R.menu.menu_refresh, menu);
+        inflater.inflate(R.menu.menu_main_events, menu);
         //TODO there must a better of doing this
         BaseActivity activity = (BaseActivity) getActivity();
-        BaseActivity.tintToolbarIcons(activity.getToolbar(), menu, R.id.action_refresh);
+        activity.tintToolbarIcons(menu, R.id.action_refresh);
+        SearchView view = (SearchView) menu.findItem(R.id.action_search).getActionView();
+        view.setOnQueryTextListener(adapter);
+        view.setOnCloseListener(adapter);
+        view.setOnSearchClickListener(v -> adapter.onOpen());
     }
 
     @Override

--- a/app/src/main/res/menu/menu_main_events.xml
+++ b/app/src/main/res/menu/menu_main_events.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item android:id="@+id/action_search"
+        android:title="@string/action_search"
+        app:actionViewClass="android.support.v7.widget.SearchView"
+        app:showAsAction="always"
+        android:iconifiedByDefault="true"
+        android:orderInCategory="10" />
+
+    <item
+        android:id="@+id/action_refresh"
+        android:icon="@drawable/ic_refresh"
+        android:orderInCategory="50"
+        app:showAsAction="ifRoom"
+        android:title="@string/action_refresh" />
+</menu>


### PR DESCRIPTION
Add searching to DSA activities.

An event appears as a match if the event's title or the association's name contains the search string. We don't search through the description at the moment. Searching happens on the main thread (as it is more a filter than a real search), so including descriptions could cause problems (because they can become too long).

Implements #117 (finally).