### PR TITLE
Add Schamper colours

### DIFF
--- a/app/src/main/java/be/ugent/zeus/hydra/data/models/schamper/Article.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/data/models/schamper/Article.java
@@ -2,17 +2,16 @@ package be.ugent.zeus.hydra.data.models.schamper;
 
 import android.os.Parcel;
 import android.os.Parcelable;
+import android.text.TextUtils;
+
 import be.ugent.zeus.hydra.data.gson.ZonedThreeTenAdapter;
 import be.ugent.zeus.hydra.utils.DateUtils;
-import be.ugent.zeus.hydra.utils.TtbUtils;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;
 import org.threeten.bp.LocalDateTime;
 import org.threeten.bp.ZonedDateTime;
 
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Created by feliciaan on 16/06/16.
@@ -29,7 +28,12 @@ public final class Article implements Serializable, Parcelable {
     private String image;
     private String category;
     private String intro;
-    private ArrayList<ArticleImage> images;
+    @SerializedName("category_color")
+    private String categoryColour;
+
+    public Article() {
+        // Empty constructor for Gson
+    }
 
     public String getTitle() {
         return title;
@@ -63,12 +67,16 @@ public final class Article implements Serializable, Parcelable {
         return intro;
     }
 
-    public List<ArticleImage> getImages() {
-        return images;
-    }
-
     public String getImage() {
         return image;
+    }
+
+    public String getCategoryColour() {
+        return categoryColour;
+    }
+
+    public boolean hasCategoryColour() {
+        return !TextUtils.isEmpty(categoryColour);
     }
 
     public String getLargeImage() {
@@ -84,51 +92,6 @@ public final class Article implements Serializable, Parcelable {
     }
 
     @Override
-    public int describeContents() {
-        return 0;
-    }
-
-    @Override
-    public void writeToParcel(Parcel dest, int flags) {
-        dest.writeString(this.title);
-        dest.writeString(this.link);
-        dest.writeLong(TtbUtils.serialize(this.pubDate));
-        dest.writeString(this.author);
-        dest.writeString(this.body);
-        dest.writeString(this.image);
-        dest.writeString(this.category);
-        dest.writeString(this.intro);
-        dest.writeTypedList(this.images);
-    }
-
-    public Article() {
-    }
-
-    private Article(Parcel in) {
-        this.title = in.readString();
-        this.link = in.readString();
-        this.pubDate = TtbUtils.unserialize(in.readLong());
-        this.author = in.readString();
-        this.body = in.readString();
-        this.image = in.readString();
-        this.category = in.readString();
-        this.intro = in.readString();
-        this.images = in.createTypedArrayList(ArticleImage.CREATOR);
-    }
-
-    public static final Creator<Article> CREATOR = new Creator<Article>() {
-        @Override
-        public Article createFromParcel(Parcel source) {
-            return new Article(source);
-        }
-
-        @Override
-        public Article[] newArray(int size) {
-            return new Article[size];
-        }
-    };
-
-    @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
@@ -141,4 +104,44 @@ public final class Article implements Serializable, Parcelable {
     public int hashCode() {
         return java8.util.Objects.hash(link, pubDate);
     }
+
+    protected Article(Parcel in) {
+        title = in.readString();
+        link = in.readString();
+        author = in.readString();
+        body = in.readString();
+        image = in.readString();
+        category = in.readString();
+        intro = in.readString();
+        categoryColour = in.readString();
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeString(title);
+        dest.writeString(link);
+        dest.writeString(author);
+        dest.writeString(body);
+        dest.writeString(image);
+        dest.writeString(category);
+        dest.writeString(intro);
+        dest.writeString(categoryColour);
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    public static final Creator<Article> CREATOR = new Creator<Article>() {
+        @Override
+        public Article createFromParcel(Parcel in) {
+            return new Article(in);
+        }
+
+        @Override
+        public Article[] newArray(int size) {
+            return new Article[size];
+        }
+    };
 }

--- a/app/src/main/java/be/ugent/zeus/hydra/data/sync/minerva/helpers/NotificationHelper.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/data/sync/minerva/helpers/NotificationHelper.java
@@ -7,6 +7,7 @@ import android.app.TaskStackBuilder;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Parcelable;
+import android.support.annotation.ColorInt;
 import android.support.annotation.DrawableRes;
 import android.support.v4.app.NotificationCompat;
 import android.support.v4.app.NotificationManagerCompat;
@@ -34,8 +35,6 @@ import static android.support.v4.app.NotificationCompat.CATEGORY_EMAIL;
  */
 public class NotificationHelper {
 
-    public static final int NOTIFICATION_ID = 5646;
-
     private static final int MAX_NUMBER_OF_LINES = 5;
 
     private final Context context;
@@ -43,12 +42,23 @@ public class NotificationHelper {
     @DrawableRes
     private int smallIcon;
 
+    @ColorInt
+    private int notificationColour;
+
     NotificationHelper(Context context) {
         this.context = context.getApplicationContext();
         //Set default values
         smallIcon = R.drawable.ic_notification_announcement;
+        notificationColour = ContextCompat.getColor(context, R.color.ugent_blue_medium);
     }
 
+    /**
+     * Strip the HTML tags from a string. This is useful for showing text inside a notification.
+     *
+     * @param containingHtml The text with the HTML tags.
+     *
+     * @return The same text with the HTML tags stripped.
+     */
     private String stripHtml(String containingHtml) {
         return Utils.fromHtml(containingHtml).toString();
     }
@@ -127,7 +137,7 @@ public class NotificationHelper {
                     .setStyle(bigTextStyle)
                     .setGroup(course.getId())
                     .setContentIntent(upIntentOne(announcement))
-                    .setColor(ContextCompat.getColor(context, R.color.ugent_blue_medium));
+                    .setColor(notificationColour);
 
             manager.notify(course.getId(), announcement.getItemId(), builder.build());
         }
@@ -180,6 +190,7 @@ public class NotificationHelper {
                 .setContentTitle(getNotificationCourseTitle(course))
                 .setContentText(context.getResources().getQuantityString(R.plurals.home_feed_announcement_title, announcements.size(), announcements.size()))
                 .setContentIntent(upIntentMore(course))
+                .setColor(notificationColour)
                 .setStyle(inboxStyle)
                 .setNumber(announcements.size())
                 .setGroupSummary(true)

--- a/app/src/main/java/be/ugent/zeus/hydra/ui/main/homefeed/content/schamper/SchamperViewHolder.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/ui/main/homefeed/content/schamper/SchamperViewHolder.java
@@ -1,5 +1,10 @@
 package be.ugent.zeus.hydra.ui.main.homefeed.content.schamper;
 
+import android.graphics.Color;
+import android.text.Spannable;
+import android.text.SpannableString;
+import android.text.TextUtils;
+import android.text.style.ForegroundColorSpan;
 import android.view.View;
 import android.widget.ImageView;
 import android.widget.TextView;
@@ -43,7 +48,18 @@ public class SchamperViewHolder extends FeedViewHolder {
         Article article = card.<SchamperCard>checkCard(HomeCard.CardType.SCHAMPER).getArticle();
 
         title.setText(article.getTitle());
-        date.setText(DateUtils.relativeDateTimeString(article.getPubDate(), itemView.getContext()));
+
+        // Construct coloured text
+        Spannable category;
+        if (article.hasCategoryColour()) {
+            int colour = Color.parseColor(article.getCategoryColour());
+            category = new SpannableString(article.getCategory());
+            category.setSpan(new ForegroundColorSpan(colour), 0, category.length(), Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
+        } else {
+            category = new SpannableString(article.getCategory());
+        }
+
+        date.setText(TextUtils.concat(DateUtils.relativeDateTimeString(article.getPubDate(), itemView.getContext()), " • ", category));
         author.setText(article.getAuthor());
 
         FeedUtils.loadThumbnail(itemView.getContext(), article.getImage(), image);

--- a/app/src/main/java/be/ugent/zeus/hydra/ui/main/schamper/SchamperViewHolder.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/ui/main/schamper/SchamperViewHolder.java
@@ -1,5 +1,8 @@
 package be.ugent.zeus.hydra.ui.main.schamper;
 
+import android.graphics.Color;
+import android.support.annotation.ColorInt;
+import android.support.v7.widget.CardView;
 import android.view.View;
 import android.widget.ImageView;
 import android.widget.TextView;
@@ -9,6 +12,7 @@ import be.ugent.zeus.hydra.data.models.schamper.Article;
 import be.ugent.zeus.hydra.ui.SchamperArticleActivity;
 import be.ugent.zeus.hydra.ui.common.customtabs.ActivityHelper;
 import be.ugent.zeus.hydra.ui.common.recyclerview.viewholders.DataViewHolder;
+import be.ugent.zeus.hydra.utils.ColourUtils;
 import be.ugent.zeus.hydra.utils.DateUtils;
 import be.ugent.zeus.hydra.utils.NetworkUtils;
 import com.squareup.picasso.Picasso;
@@ -25,17 +29,30 @@ class SchamperViewHolder extends DataViewHolder<Article> {
     private final TextView author;
     private final TextView category;
     private final ImageView image;
+    private final CardView schamperCardView;
 
     private final ActivityHelper helper;
+
+    @ColorInt private final int initialTitleColour;
+    @ColorInt private final int initialDateColour;
+    @ColorInt private final int initialAuthorColour;
+    @ColorInt private final int initialCategoryColour;
+    @ColorInt private final int initialCardViewColour;
 
     SchamperViewHolder(View itemView, ActivityHelper helper) {
         super(itemView);
 
         title = itemView.findViewById(R.id.title);
+        initialTitleColour = title.getCurrentTextColor();
         date = itemView.findViewById(R.id.date);
+        initialDateColour = date.getCurrentTextColor();
         author = itemView.findViewById(R.id.author);
+        initialAuthorColour = author.getCurrentTextColor();
         image = itemView.findViewById(R.id.card_image);
         category = itemView.findViewById(R.id.schamper_category);
+        initialCategoryColour = category.getCurrentTextColor();
+        schamperCardView = itemView.findViewById(R.id.schamper_card_view);
+        initialCardViewColour = schamperCardView.getCardBackgroundColor().getDefaultColor();
         this.helper = helper;
     }
 
@@ -45,6 +62,21 @@ class SchamperViewHolder extends DataViewHolder<Article> {
         author.setText(article.getAuthor());
         category.setText(article.getCategory());
 
+        if (article.hasCategoryColour()) {
+            int colour = Color.parseColor(article.getCategoryColour());
+            if (ColourUtils.isDark(colour)) {
+                schamperCardView.setCardBackgroundColor(Color.parseColor(article.getCategoryColour()));
+                title.setTextColor(Color.WHITE);
+                date.setTextColor(Color.WHITE);
+                author.setTextColor(Color.WHITE);
+                category.setTextColor(Color.WHITE);
+            } else {
+                setDefaultColours();
+            }
+        } else {
+            setDefaultColours();
+        }
+
         if (NetworkUtils.isMeteredConnection(itemView.getContext())) {
             Picasso.with(this.itemView.getContext()).load(article.getImage()).into(image);
         } else {
@@ -52,5 +84,13 @@ class SchamperViewHolder extends DataViewHolder<Article> {
         }
 
         this.itemView.setOnClickListener(v -> SchamperArticleActivity.viewArticle(v.getContext(), article, helper, image));
+    }
+
+    private void setDefaultColours() {
+        title.setTextColor(initialTitleColour);
+        date.setTextColor(initialDateColour);
+        author.setTextColor(initialAuthorColour);
+        category.setTextColor(initialCategoryColour);
+        schamperCardView.setCardBackgroundColor(initialCardViewColour);
     }
 }

--- a/app/src/main/java/be/ugent/zeus/hydra/utils/ColourUtils.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/utils/ColourUtils.java
@@ -1,0 +1,24 @@
+package be.ugent.zeus.hydra.utils;
+
+import android.support.annotation.ColorInt;
+import android.support.v4.graphics.ColorUtils;
+
+/**
+ * @author Niko Strijbol
+ */
+public class ColourUtils {
+
+    /**
+     * Returns true if a colour is considered dark. A colour is dark if the light component is less than 0,6.
+     *
+     * @param colorInt The colour int.
+     *
+     * @return True if dark, false otherwise.
+     */
+    public static boolean isDark(@ColorInt int colorInt) {
+        float hsl[] = new float[3];
+        ColorUtils.colorToHSL(colorInt, hsl);
+        return hsl[2] < 0.6f;
+    }
+
+}

--- a/app/src/main/res/layout/item_schamper.xml
+++ b/app/src/main/res/layout/item_schamper.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <android.support.v7.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/schamper_card_view"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"


### PR DESCRIPTION
Since this was not completed entirely during the codenight, I have implemented it here, using the values from the API.

In the main Schamper list I have used the accent colour as the background colour, since I think it looks nice, but if people don't like it, we can easily change it back.

In the homefeed:
![device-2017-10-18-225917](https://user-images.githubusercontent.com/1756811/31742538-3327a190-b458-11e7-8f2d-69cf428b6050.png)

In the main list:
![device-2017-10-18-225941](https://user-images.githubusercontent.com/1756811/31742539-334a9cd6-b458-11e7-94ef-8cafbf3cde85.png)
