### PR TITLE
Add prefix options and improve duplicate detection

### DIFF
--- a/app/src/main/java/be/ugent/zeus/hydra/ui/preferences/MinervaFragment.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/ui/preferences/MinervaFragment.java
@@ -28,8 +28,10 @@ public class MinervaFragment extends PreferenceFragment {
     public static final String PREF_ANNOUNCEMENT_NOTIFICATION_EMAIL = "pref_minerva_announcement_notification_email";
     public static final String PREF_USE_MOBILE_URL = "pref_minerva_use_mobile_url";
 
-
     public static final String PREF_DETECT_DUPLICATES = "pref_minerva_detect_duplicates";
+
+    public static final String PREF_PREFIX_EVENT_TITLES = "pref_minerva_prefix_event_titles";
+    public static final String PREF_PREFIX_EVENT_ACRONYM = "pref_minerva_prefix_event_acronym";
 
     //In seconds
     public static final String PREF_DEFAULT_SYNC_FREQUENCY = "86400";
@@ -40,6 +42,12 @@ public class MinervaFragment extends PreferenceFragment {
 
     private boolean oldDetectDuplicates;
     private boolean newDetectDuplicates;
+
+    private boolean oldPrefixEventTitles;
+    private boolean newPrefixEventTitles;
+
+    private boolean oldPrefixAcronyms;
+    private boolean newPrefixAcronyms;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -63,9 +71,17 @@ public class MinervaFragment extends PreferenceFragment {
         oldDetectDuplicates = preferences.getBoolean(PREF_DETECT_DUPLICATES, false);
         newDetectDuplicates = oldDetectDuplicates;
 
+        oldPrefixEventTitles = preferences.getBoolean(PREF_PREFIX_EVENT_TITLES, false);
+        newPrefixEventTitles = oldPrefixEventTitles;
+
+        oldPrefixAcronyms = preferences.getBoolean(PREF_PREFIX_EVENT_ACRONYM, true);
+        newPrefixAcronyms = oldPrefixAcronyms;
 
         Preference intervalPreference = findPreference(PREF_SYNC_FREQUENCY);
         Preference detectPreference = findPreference(PREF_DETECT_DUPLICATES);
+        Preference prefixTitles = findPreference(PREF_PREFIX_EVENT_TITLES);
+        Preference prefixAbbreviations = findPreference(PREF_PREFIX_EVENT_ACRONYM);
+        prefixAbbreviations.setEnabled(oldPrefixEventTitles);
 
         intervalPreference.setOnPreferenceChangeListener((preference, newValue) -> {
             newInterval = Integer.parseInt((String) newValue);
@@ -74,6 +90,17 @@ public class MinervaFragment extends PreferenceFragment {
 
         detectPreference.setOnPreferenceChangeListener((preference, newValue) -> {
             newDetectDuplicates = (boolean) newValue;
+            return true;
+        });
+
+        prefixTitles.setOnPreferenceChangeListener((preference, newValue) -> {
+            newPrefixEventTitles = (boolean) newValue;
+            prefixAbbreviations.setEnabled(newPrefixEventTitles);
+            return true;
+        });
+
+        prefixAbbreviations.setOnPreferenceChangeListener((preference, newValue) -> {
+            newPrefixAcronyms = (boolean) newValue;
             return true;
         });
 
@@ -89,7 +116,7 @@ public class MinervaFragment extends PreferenceFragment {
         if (hasAccount && oldInterval != newInterval) {
             SyncUtils.changeSyncFrequency(getAppContext(), MinervaConfig.SYNC_AUTHORITY, newInterval);
         }
-        if (hasAccount && oldDetectDuplicates != newDetectDuplicates) {
+        if (hasAccount && (oldDetectDuplicates != newDetectDuplicates || oldPrefixEventTitles != newPrefixEventTitles || oldPrefixAcronyms != newPrefixAcronyms)) {
             Bundle bundle = new Bundle();
             bundle.putBoolean(MinervaAdapter.SYNC_ANNOUNCEMENTS, false);
             SyncUtils.requestSync(AccountUtils.getAccount(getAppContext()), MinervaConfig.SYNC_AUTHORITY, bundle);

--- a/app/src/main/java/be/ugent/zeus/hydra/utils/StringUtils.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/utils/StringUtils.java
@@ -31,4 +31,34 @@ public class StringUtils {
         java.util.Scanner s = new java.util.Scanner(is).useDelimiter("\\A");
         return s.hasNext() ? s.next() : "";
     }
+
+    /**
+     * Generate an acronym for a string. This will split the string on whitespace, take the first letter of every word,
+     * capitalize that first letter and concat the result. If a word does not contain any letters, it is fully added.
+     *
+     * For example, {@code Algoritmen en datastructuren III} will become {@code AEDIII}.
+     *
+     * TODO: can we make this less dumb, and ignore words as 'en', 'of', etc?
+     *
+     * @param name The string to acronymize.
+     *
+     * @return The acronym.
+     */
+    public static String generateAcronymFor(String name) {
+        StringBuilder result = new StringBuilder();
+        for (String word : name.split("\\s")) {
+            int i = 0;
+            char c;
+            do {
+                c = word.charAt(i++);
+            } while (!Character.isLetter(c) && i < word.length());
+            if (Character.isLetter(c)) {
+                result.append(Character.toUpperCase(c));
+            } else {
+                // There are no letters in this part, so just add it completely.
+                result.append(word);
+            }
+        }
+        return result.toString();
+    }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" xmlns:tools="http://schemas.android.com/tools">
 
     <!-- General -->
     <string name="app_name">Hydra</string>
@@ -204,6 +204,12 @@
     <string name="events_no_location">Zonder locatie</string>
     <string name="title_license">Licenties</string>
     <string name="agenda_subtitle">%1$s • %2$s</string>
+    <string name="minerva_calendar_device_event_title">
+        <xliff:g id="course_name" example="Machinaal leren">%1$s</xliff:g>: <xliff:g id="event_title" example="Inleiding en afspraken">%2$s</xliff:g>
+    </string>
+    <string name="minerva_calendar_device_description">
+        Les van het vak <xliff:g id="course_name" example="Machinaal leren">%1$s</xliff:g>
+    </string>
     <plurals name="home_feed_announcement_title">
         <item quantity="one">%d aankondiging</item>
         <item quantity="other">%d aankondigingen</item>

--- a/app/src/main/res/xml/pref_minerva.xml
+++ b/app/src/main/res/xml/pref_minerva.xml
@@ -44,6 +44,19 @@
 
     </PreferenceCategory>
 
+    <PreferenceCategory android:title="Agenda">
+        <CheckBoxPreference
+            android:key="pref_minerva_prefix_event_titles"
+            android:title="Vak toevoegen aan agenda-items"
+            android:summary="Voeg de naam van het vak toe aan de titel van evenementen als die titel niet de naam van het vak is."
+            android:defaultValue="false" />
+        <CheckBoxPreference
+            android:key="pref_minerva_prefix_event_acronym"
+            android:title="Vaknaam afkorten"
+            android:summary="Gebruik acroniemen als naam van het van in de titel van evenementen."
+            android:defaultValue="true" />
+    </PreferenceCategory>
+
     <PreferenceCategory android:title="Duplicatendetectie (experimenteel)">
 
         <CheckBoxPreference

--- a/app/src/main/res/xml/pref_minerva.xml
+++ b/app/src/main/res/xml/pref_minerva.xml
@@ -53,7 +53,7 @@
         <CheckBoxPreference
             android:key="pref_minerva_prefix_event_acronym"
             android:title="Vaknaam afkorten"
-            android:summary="Gebruik acroniemen als naam van het van in de titel van evenementen."
+            android:summary="Gebruik acroniemen als naam van het vak in de titel van evenementen."
             android:defaultValue="true" />
     </PreferenceCategory>
 


### PR DESCRIPTION
- Add an option to add the course's name as a prefix to events in the device calendar.
  * The prefix can be the full app name, or a generated acronym.
  * This will not happen if the title of the event is already the course name. For example, with both options enabled, for the course `Machinaal leren`, two events A: `Machinaal leren` and B: `Statistische grondslagen`, the result would be A: `Machinaal leren` (no change) and B: `ML: Statistische grondslagen`.
- Improve duplication detection
  * If the API indicates an event was hidden, we now also hide the event.
  * In rare cases where there are multiple events on the same time for the same course with different pairs of titles, they are also recognised. For example, assume we have for some course event A, B, C and D at the same time. Further, assume A and B have title `foo` and C and D have title `bar`. Previously, these would not have been merged. Now, the events are merged: the result is A+B and C+D.
- Better removal of stale events in the device calendar. Sometimes events would be removed from our internal database but not from the device calendar, but then those are stuck inside the device calendar.