### PR TITLE
Automatic releases

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -271,3 +271,6 @@ ij_xml_space_around_equals_in_attribute = false
 ij_xml_space_inside_empty_tag = true
 ij_xml_text_wrap = normal
 ij_xml_use_custom_settings = true
+
+[*yml]
+indent_size = 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,7 @@
 name: CI
 
 # We run the tests on master, development and for PR's.
-on:
-  push:
-    branches:
-      - master
-      - development
-  pull_request:
+on: [push]
 
 jobs:
   test:
@@ -16,39 +11,87 @@ jobs:
       matrix:
         command: [testOpenDebug, testOpenRelease, testStoreDebug, testStoreRelease]
     steps:
-      - uses: actions/checkout@v1
-      - name: Set up JDK
+      - uses: actions/checkout@v2
+      - name: Set up JDK 13
         uses: actions/setup-java@v1
         with:
           java-version: 13
-      - name: Cache Gradle files
-        uses: actions/cache@v1
+      - name: Cache Gradle packages
+        uses: actions/cache@v2
         with:
           path: ~/.gradle/caches
           key: ${{ matrix.command }}-${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-          restore-keys: |
-            ${{ matrix.command }}-${{ runner.os }}-gradle-
+          restore-keys: ${{ matrix.command }}-${{ runner.os }}-gradle
       - name: Test with Gradle
-        uses: eskatos/gradle-command-action@v1
-        with:
-          arguments: ${{ matrix.command }}
+        run: ./gradlew ${{ matrix.command }}
   lint:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - name: Set up JDK
+      - uses: actions/checkout@v2
+      - name: Set up JDK 13
         uses: actions/setup-java@v1
         with:
           java-version: 13
-      - name: Cache Gradle files
-        uses: actions/cache@v1
+      - name: Cache Gradle packages
+        uses: actions/cache@v2
         with:
           path: ~/.gradle/caches
           key: lint-${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-          restore-keys: |
-            lint-${{ runner.os }}-gradle-
-      - name: Lint with Gradle
-        uses: eskatos/gradle-command-action@v1
+          restore-keys: lint-${{ runner.os }}-gradle
+      - name: Test with Gradle
+        run: ./gradlew ${{ matrix.command }}
+  build:
+    needs: test
+    name: Build app
+    runs-on: ubuntu-latest
+    # Only run on master
+    if: github.ref == 'refs/heads/master'
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 13
+        uses: actions/setup-java@v1
         with:
-          arguments: lint
+          java-version: 13
+      - name: Cache Gradle packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.gradle/caches
+          key: build-${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: build-${{ runner.os }}-gradle
+      - name: Set up secrets.properties
+        run: echo "$SECRETS_PROPERTIES" | base64 --decode > app/secrets.properties
+        env:
+          SECRETS_PROPERTIES: ${{ secrets.SECRETS_PROPERTIES }}
+      - name: Set up signging key
+        run: echo "$UPLOAD_KEY_BASE64" | base64 --decode > app/upload.keystore
+        env:
+          UPLOAD_KEY_BASE64: ${{ secrets.UPLOAD_KEY_BASE64 }}
+      - name: Build APK
+        run: ./gradlew assembleRelease
+      - name: Upload store APK
+        uses: actions/upload-artifact@v2
+        with:
+          name: hydra-store.apk
+          path: app/build/outputs/apk/store/release/app-store-release.apk
+          if-no-files-found: error
+      - name: Upload foss APK
+        uses: actions/upload-artifact@v2
+        with:
+          name: hydra-foss.apk
+          path: app/build/outputs/apk/open/release/app-open-release.apk
+          if-no-files-found: error
+      - name: Build App Bundle
+        run: ./gradlew bundleRelease
+      - name: Upload store bundle
+        uses: actions/upload-artifact@v2
+        with:
+          name: hydra-store.aab
+          path: app/build/outputs/bundle/storeRelease/app-store-release.aab
+          if-no-files-found: error
+      - name: Upload foss bundle
+        uses: actions/upload-artifact@v2
+        with:
+          name: hydra-foss.aab
+          path: app/build/outputs/bundle/openRelease/app-open-release.aab
+          if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,4 @@ app/src/main/assets/open_source_licenses.html
 app/custom-config.properties
 com.crashlytics.settings.json
 session_analytics.tap
+*.keystore

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -53,15 +53,27 @@ android {
                 "OldTargetApi"
     }
 
+    if (props["signing"]) {
+        signingConfigs {
+            upload {
+                keyAlias "upload"
+                keyPassword props['keyPassword']
+                storeFile file(props['storeFile'])
+                storePassword props['storePassword']
+                v1SigningEnabled true
+                v2SigningEnabled true
+            }
+        }
+    }
+
     flavorDimensions "distribution"
 
     productFlavors {
-
         // Play Store and officially supported version
         store {
             isDefault = true
             manifestPlaceholders = [
-                    google_maps_key: props.getProperty('MAPS_API_KEY'),
+                    google_maps_key: props.getProperty('mapsApiKey'),
             ]
         }
 
@@ -80,7 +92,6 @@ android {
         test.resources.srcDirs += files("$projectDir/schemas".toString())
     }
 
-    //noinspection GroovyMissingReturnStatement
     compileOptions {
         coreLibraryDesugaringEnabled true
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -91,11 +102,15 @@ android {
         release {
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            if (props["signing"]) {
+                signingConfig signingConfigs.upload
+            }
         }
 
         debug {
             // Disable crashlytics in debug builds if necessary.
             ext.enableCrashlytics = Boolean.parseBoolean(props.getProperty("hydra.debug.reporting"))
+            testCoverageEnabled true
         }
     }
 
@@ -201,7 +216,6 @@ android.applicationVariants.all { variant ->
  * secret keys.
  */
 def loadProperties() {
-
     // Load the default properties.
     def defaultProps = new Properties()
     defaultProps.load(file("config.properties").newReader())

--- a/app/secrets.properties.example
+++ b/app/secrets.properties.example
@@ -1,1 +1,5 @@
-MAPS_API_KEY=< fill in >
+mapsApiKey=<fill in>
+signing=false
+storePassword=<FILL IN>
+keyPassword=<FILL IN>
+storeFile=<FILL IN>


### PR DESCRIPTION
- Adds a GitHub Action that will automatically create a signed APK and GitHub release for certain tags.
- Removes Travis integration

In the long term, these automatic releases could be pushed to the Play Store automatically.

----

Security wise, the risk is not 0%: it is possible to get the keystore file from the actions. However, this requires write-access to the repo, which means it basically boils down to if we trust Zeus WPI members or not. (I assume we do). 

Note that other repositories with automatic deployment, such as https://github.com/ZeusWPI/hydra and https://github.com/ZeusWPI/zeus.ugent.be have the same problem.

However, one complication is that the Android keystore cannot be changed. In the case of the other repo's, we can always change SSH keys on the server.

For this reason, I suggest we wait until we have implemented [App signing by Google Play](https://developer.android.com/studio/publish/app-signing#app-signing-google-play), which would allow us to request a reset of the key in the action.

This last bit is blocked by #307.