### PR TITLE
Gather analytics about card dismissals

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -32,6 +32,7 @@ android {
         buildConfigField "boolean", "DEBUG_ENABLE_STRICT_MODE", props.getProperty('hydra.debug.strict_mode')
         buildConfigField "boolean", "DEBUG_ENABLE_ALL_SPECIALS", props.getProperty('hydra.debug.home.stream.specials')
         buildConfigField "boolean", "DEBUG_TRACK_LEAKS", props.getProperty("hydra.debug.leaks")
+        buildConfigField "boolean", "DEBUG_ENABLE_REPORTING", props.getProperty("hydra.debug.reporting")
 
         // used by Room, to test migrations
         javaCompileOptions {
@@ -60,8 +61,8 @@ android {
 
         debug {
             multiDexEnabled true
-            // Disable crashlytics in debug builds
-            ext.enableCrashlytics = false
+            // Disable crashlytics in debug builds if necessary.
+            ext.enableCrashlytics = Boolean.parseBoolean(props.getProperty("hydra.debug.reporting"))
         }
     }
 

--- a/app/config.properties
+++ b/app/config.properties
@@ -21,3 +21,5 @@ hydra.debug.home.stream.specials = false
 hydra.debug.strict_mode = false
 # Enable memory-leak tracking with LeakyCanary
 hydra.debug.leaks = false
+# Allow debug analytics and crash reporting
+hydra.debug.reporting = false

--- a/app/src/main/java/be/ugent/zeus/hydra/common/reporting/BaseEvents.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/common/reporting/BaseEvents.java
@@ -80,6 +80,19 @@ public interface BaseEvents {
      */
     String viewItem();
 
+    /**
+     * A custom event to report that the user has dismissed a card from the home feed.
+     *
+     * Params:
+     * <ul>
+     *     <li>{@link Params#dismissalType()}</li>
+     *     <li>{@link Params#cardType()}</li>
+     *     <li>{@link Params#cardIdentifier()}</li>
+     * </ul>
+     *
+     */
+    String cardDismissal();
+
     interface Params {
         /**
          * A particular approach used in an operation; for example, "facebook" or "email" in the context of a sign_up or
@@ -111,5 +124,20 @@ public interface BaseEvents {
          * Item category (String).
          */
         String itemCategory();
+
+        /**
+         * Dismissal type (String)
+         */
+        String dismissalType();
+
+        /**
+         * Card type (int)
+         */
+        String cardType();
+
+        /**
+         * Card identifier (String)
+         */
+        String cardIdentifier();
     }
 }

--- a/app/src/main/java/be/ugent/zeus/hydra/common/reporting/FirebaseEvents.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/common/reporting/FirebaseEvents.java
@@ -58,6 +58,11 @@ final class FirebaseEvents implements BaseEvents {
         return FirebaseAnalytics.Event.VIEW_ITEM;
     }
 
+    @Override
+    public String cardDismissal() {
+        return "card_dismissal";
+    }
+
     private final static class FirebaseParams implements BaseEvents.Params {
 
         @Override
@@ -88,6 +93,21 @@ final class FirebaseEvents implements BaseEvents {
         @Override
         public String itemCategory() {
             return FirebaseAnalytics.Param.ITEM_CATEGORY;
+        }
+
+        @Override
+        public String dismissalType() {
+            return "dismissal_type";
+        }
+
+        @Override
+        public String cardType() {
+            return "card_type";
+        }
+
+        @Override
+        public String cardIdentifier() {
+            return "card_identifier";
         }
     }
 }

--- a/app/src/main/java/be/ugent/zeus/hydra/common/reporting/Reporting.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/common/reporting/Reporting.java
@@ -3,8 +3,8 @@ package be.ugent.zeus.hydra.common.reporting;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.util.Log;
+import androidx.annotation.VisibleForTesting;
 import androidx.preference.PreferenceManager;
-
 import be.ugent.zeus.hydra.BuildConfig;
 
 /**
@@ -26,7 +26,6 @@ public final class Reporting {
      * Get the default tracker.
      *
      * @param context The context.
-     *
      * @return The tracker.
      */
     public static Tracker getTracker(Context context) {
@@ -59,7 +58,7 @@ public final class Reporting {
     /**
      * Sync the collecting of data with the user preference and the build type. By default, analytics
      * is opt-in, while crash reporting is opt-out.
-     *
+     * <p>
      * Additionally, both analytics and crash reporting will be disabled on debug builds.
      *
      * @param context The context.
@@ -87,5 +86,10 @@ public final class Reporting {
         } else {
             return true;
         }
+    }
+
+    @VisibleForTesting
+    public static void setTracker(Tracker tracker) {
+        Reporting.tracker = tracker;
     }
 }

--- a/app/src/main/java/be/ugent/zeus/hydra/common/reporting/Reporting.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/common/reporting/Reporting.java
@@ -69,13 +69,23 @@ public final class Reporting {
         Tracker tracker = getTracker(context);
 
         // Enable or disable analytics
-        boolean areAnalyticsAllowed = preferences.getBoolean(PREF_ALLOW_ANALYTICS, false) && !BuildConfig.DEBUG;
+        boolean areAnalyticsAllowed = preferences.getBoolean(PREF_ALLOW_ANALYTICS, false) && allowDebugReporting();
         tracker.allowAnalytics(areAnalyticsAllowed);
         Log.i(TAG, "permissions: allowing analytics? " + areAnalyticsAllowed);
 
         // Enable or disable crash reporting
-        boolean isCrashReportingAllowed = preferences.getBoolean(PREF_ALLOW_CRASH_REPORTING, true) && !BuildConfig.DEBUG;
+        boolean isCrashReportingAllowed = preferences.getBoolean(PREF_ALLOW_CRASH_REPORTING, true) && allowDebugReporting();
         tracker.allowCrashReporting(isCrashReportingAllowed);
         Log.i(TAG, "permissions: allowing crash reporting? " + isCrashReportingAllowed);
+    }
+
+    public static boolean allowDebugReporting() {
+        // If a DEBUG build, use the property, otherwise OK!
+        if (BuildConfig.DEBUG) {
+            Log.d(TAG, "allowDebugReporting: this is debug mode");
+            return BuildConfig.DEBUG_ENABLE_REPORTING;
+        } else {
+            return true;
+        }
     }
 }

--- a/app/src/main/java/be/ugent/zeus/hydra/feed/commands/DisableAssociationCommand.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/feed/commands/DisableAssociationCommand.java
@@ -4,6 +4,7 @@ import android.content.Context;
 
 import be.ugent.zeus.hydra.R;
 import be.ugent.zeus.hydra.association.Association;
+import be.ugent.zeus.hydra.common.reporting.Reporting;
 import be.ugent.zeus.hydra.feed.cards.Card;
 import be.ugent.zeus.hydra.association.preference.AssociationSelectionPreferenceFragment;
 import be.ugent.zeus.hydra.utils.PreferencesUtils;
@@ -21,6 +22,7 @@ public class DisableAssociationCommand implements FeedCommand {
 
     @Override
     public int execute(Context context) {
+        Reporting.getTracker(context).log(new DismissalEvent(association));
         PreferencesUtils.addToStringSet(
                 context,
                 AssociationSelectionPreferenceFragment.PREF_ASSOCIATIONS_SHOWING,

--- a/app/src/main/java/be/ugent/zeus/hydra/feed/commands/DisableIndividualCard.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/feed/commands/DisableIndividualCard.java
@@ -2,6 +2,7 @@ package be.ugent.zeus.hydra.feed.commands;
 
 import android.content.Context;
 
+import be.ugent.zeus.hydra.common.reporting.Reporting;
 import java9.util.function.Function;
 
 import be.ugent.zeus.hydra.R;
@@ -29,6 +30,7 @@ public class DisableIndividualCard implements FeedCommand {
 
     @Override
     public int execute(Context context) {
+        Reporting.getTracker(context).log(new DismissalEvent(cardDismissal.getIdentifier()));
         DismissalDao dao = daoSupplier.apply(context);
         dao.insert(cardDismissal);
         return cardDismissal.getIdentifier().getCardType();

--- a/app/src/main/java/be/ugent/zeus/hydra/feed/commands/DisableTypeCommand.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/feed/commands/DisableTypeCommand.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import androidx.annotation.StringRes;
 
 import be.ugent.zeus.hydra.R;
+import be.ugent.zeus.hydra.common.reporting.Reporting;
 import be.ugent.zeus.hydra.feed.cards.Card;
 import be.ugent.zeus.hydra.feed.HomeFeedFragment;
 import be.ugent.zeus.hydra.utils.PreferencesUtils;
@@ -26,6 +27,7 @@ public class DisableTypeCommand implements FeedCommand {
     @Override
     @Card.Type
     public int execute(Context context) {
+        Reporting.getTracker(context).log(new DismissalEvent(cardType));
         PreferencesUtils.addToStringSet(
                 context,
                 HomeFeedFragment.PREF_DISABLED_CARD_TYPES,

--- a/app/src/main/java/be/ugent/zeus/hydra/feed/commands/DismissalEvent.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/feed/commands/DismissalEvent.java
@@ -1,0 +1,54 @@
+package be.ugent.zeus.hydra.feed.commands;
+
+import android.os.Bundle;
+import androidx.annotation.Nullable;
+import be.ugent.zeus.hydra.association.Association;
+import be.ugent.zeus.hydra.common.reporting.BaseEvents;
+import be.ugent.zeus.hydra.common.reporting.Event;
+import be.ugent.zeus.hydra.common.reporting.Reporting;
+import be.ugent.zeus.hydra.feed.cards.Card;
+import be.ugent.zeus.hydra.feed.cards.dismissal.CardIdentifier;
+
+/**
+ * Used to report that the user dismissed a card to the analytics.
+ *
+ * @author Niko Strijbol
+ */
+class DismissalEvent implements Event {
+
+    private final String dismissalType;
+    private final CardIdentifier identifier;
+
+    DismissalEvent(Association association) {
+        this.dismissalType = "association";
+        this.identifier = new CardIdentifier(Card.Type.ACTIVITY, association.getInternalName());
+    }
+
+    DismissalEvent(CardIdentifier identifier) {
+        this.dismissalType = "individual_card";
+        this.identifier = identifier;
+    }
+
+    DismissalEvent(@Card.Type int type) {
+        this.dismissalType = "card_type";
+        this.identifier = new CardIdentifier(type, "all_cards");
+    }
+
+
+    @Nullable
+    @Override
+    public Bundle getParams() {
+        Bundle bundle = new Bundle();
+        BaseEvents.Params names = Reporting.getEvents().params();
+        bundle.putString(names.dismissalType(), this.dismissalType);
+        bundle.putInt(names.cardType(), identifier.getCardType());
+        bundle.putString(names.cardIdentifier(), identifier.getIdentifier());
+        return bundle;
+    }
+
+    @Nullable
+    @Override
+    public String getEventName() {
+        return Reporting.getEvents().cardDismissal();
+    }
+}

--- a/app/src/test/java/be/ugent/zeus/hydra/feed/commands/DisableIndividualCardTest.java
+++ b/app/src/test/java/be/ugent/zeus/hydra/feed/commands/DisableIndividualCardTest.java
@@ -1,15 +1,22 @@
 package be.ugent.zeus.hydra.feed.commands;
 
+import android.app.Activity;
 import android.content.Context;
-
-import java.util.List;
-
+import androidx.annotation.NonNull;
+import be.ugent.zeus.hydra.common.reporting.Event;
+import be.ugent.zeus.hydra.common.reporting.Reporting;
+import be.ugent.zeus.hydra.common.reporting.Tracker;
 import be.ugent.zeus.hydra.feed.cards.Card;
 import be.ugent.zeus.hydra.feed.cards.dismissal.CardDismissal;
 import be.ugent.zeus.hydra.feed.cards.dismissal.CardIdentifier;
 import be.ugent.zeus.hydra.feed.cards.dismissal.DismissalDao;
 import org.junit.Test;
 import org.threeten.bp.Instant;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -27,9 +34,15 @@ public class DisableIndividualCardTest {
         CardIdentifier identifier = new CardIdentifier(Card.Type.DEBUG, "test");
         CardDismissal cardDismissal = new CardDismissal(identifier, Instant.now());
         Context context = mock(Context.class);
+        MemoryTracker tracker = new MemoryTracker();
+        tracker.allowAnalytics(true);
+        tracker.allowCrashReporting(true);
+        Reporting.setTracker(tracker);
 
         DisableIndividualCard disableIndividualCard = new DisableIndividualCard(cardDismissal, c -> repository);
         disableIndividualCard.execute(context);
+
+        assertEquals(1, tracker.logged.size());
 
         List<CardDismissal> dismissals = repository.getForType(Card.Type.DEBUG);
         assertEquals(1, dismissals.size());
@@ -39,5 +52,57 @@ public class DisableIndividualCardTest {
 
         List<CardDismissal> newDismissals = repository.getForType(Card.Type.DEBUG);
         assertTrue(newDismissals.isEmpty());
+    }
+
+    private static class MemoryTracker implements Tracker {
+
+        private final List<Event> logged = new ArrayList<>();
+        private final Map<String, String> userValues = new HashMap<>();
+        private final List<Throwable> errors = new ArrayList<>();
+        private final List<String> errorMessages = new ArrayList<>();
+
+        private boolean allowingAnalytics;
+        private boolean allowingCrashReporting;
+
+        @Override
+        public void log(Event event) {
+            if (allowingAnalytics) {
+                logged.add(event);
+            }
+        }
+
+        @Override
+        public void setCurrentScreen(@NonNull Activity activity, String screenName, String classOverride) {
+            // do nothing
+        }
+
+        @Override
+        public void setUserProperty(String name, String value) {
+            userValues.put(name, value);
+        }
+
+        @Override
+        public void logError(Throwable throwable) {
+            if (allowingCrashReporting) {
+                this.errors.add(throwable);
+            }
+        }
+
+        @Override
+        public void logErrorMessage(String message) {
+            if (allowingCrashReporting) {
+                this.errorMessages.add(message);
+            }
+        }
+
+        @Override
+        public void allowAnalytics(boolean allowed) {
+            this.allowingAnalytics = allowed;
+        }
+
+        @Override
+        public void allowCrashReporting(boolean allowed) {
+            this.allowingCrashReporting = allowed;
+        }
     }
 }


### PR DESCRIPTION
As said in the commit; this is useful for two reasons:
- This might provide insightful data, so we can prioritise the cards better.
- There are some very rare crashes related to card dismissals. This will allow us to collect more data to see when and for which card they occur.