### PR TITLE
Migrate off old DSA API

### DIFF
--- a/app/src/main/java/be/ugent/zeus/hydra/common/network/Endpoints.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/common/network/Endpoints.java
@@ -6,9 +6,9 @@ package be.ugent.zeus.hydra.common.network;
  * @author Niko Strijbol
  */
 public interface Endpoints {
-
-    String DSA_V3 = "http://student.ugent.be/hydra/api/3.0/";
     String DSA_V4 = "https://dsa.ugent.be/api/";
+    
+    String UGENT = "https://www.ugent.be/";
 
     String ZEUS_V1 = "https://hydra.ugent.be/api/1.0/";
     String ZEUS_V2 = "https://hydra.ugent.be/api/2.0/";

--- a/app/src/main/java/be/ugent/zeus/hydra/news/UgentNewsRequest.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/news/UgentNewsRequest.java
@@ -9,6 +9,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
+import be.ugent.zeus.hydra.R;
 import be.ugent.zeus.hydra.common.network.Endpoints;
 import be.ugent.zeus.hydra.common.network.JsonArrayRequest;
 import be.ugent.zeus.hydra.common.request.Result;
@@ -19,9 +20,12 @@ import be.ugent.zeus.hydra.common.request.Result;
  * @author feliciaan
  */
 public class UgentNewsRequest extends JsonArrayRequest<UgentNewsArticle> {
+    
+    private final Context context;
 
     public UgentNewsRequest(Context context) {
         super(context, UgentNewsArticle.class);
+        this.context = context.getApplicationContext();
     }
 
     @NonNull
@@ -36,7 +40,8 @@ public class UgentNewsRequest extends JsonArrayRequest<UgentNewsArticle> {
     @NonNull
     @Override
     protected String getAPIUrl() {
-        return Endpoints.DSA_V3 + "recent_news.json";
+        String endpoint = context.getString(R.string.ugent_news_endpoint);
+        return Endpoints.UGENT + endpoint;
     }
 
     @Override

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -324,4 +324,6 @@
     <string name="content_desc_youtube">YouTube</string>
     <string name="content_desc_select_all">Select all</string>
     <string name="content_desc_select_none">Select none</string>
+
+    <string name="ugent_news_endpoint">en/news-events/overview/@@rss2json</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -330,4 +330,6 @@
     <string name="content_desc_youtube">YouTube</string>
     <string name="content_desc_select_all">Alles selecteren</string>
     <string name="content_desc_select_none">Niets selecteren</string>
+    
+    <string name="ugent_news_endpoint">nl/actueel/overzicht/@@rss2json</string>
 </resources>


### PR DESCRIPTION
With this change, we now no longer use student.ugent.be in the Android app 🎉 

Additionally, using the UGent URLs directly allows us to support English news if the app is set to English.