### PR TITLE
Disable beep in open scanner

### DIFF
--- a/app/src/open/java/be/ugent/zeus/hydra/common/barcode/OpenBarcodeScanner.java
+++ b/app/src/open/java/be/ugent/zeus/hydra/common/barcode/OpenBarcodeScanner.java
@@ -47,6 +47,7 @@ class OpenBarcodeScanner implements BarcodeScanner {
     public Intent getActivityIntent(Activity activity) {
         IntentIntegrator integrator = new IntentIntegrator(activity);
         integrator.setDesiredBarcodeFormats(IntentIntegrator.PRODUCT_CODE_TYPES);
+        integrator.setBeepEnabled(false);
         return integrator.createScanIntent();
     }
     


### PR DESCRIPTION
This change was highly requested by all users of the open variant.
While the beep has its charms, it is better in most cases to not make
an unexpected sound. Additionally, the Play Store variant also doesn't
make a sound, so this makes the functionality equal.