### PR TITLE
Dagschotel shortcut

### DIFF
--- a/app/src/main/java/be/ugent/zeus/hydra/wpi/tap/cart/CartActivity.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/wpi/tap/cart/CartActivity.java
@@ -29,6 +29,7 @@ import android.view.*;
 import android.widget.Toast;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.content.pm.ShortcutManagerCompat;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.recyclerview.widget.RecyclerView;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
@@ -52,6 +53,8 @@ import be.ugent.zeus.hydra.wpi.tap.product.Product;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.android.material.snackbar.Snackbar;
 
+import static be.ugent.zeus.hydra.wpi.tap.product.ProductFragment.FAVOURITE_PINNED_SHORTCUT;
+
 /**
  * The Tap cart.
  *
@@ -63,6 +66,7 @@ public class CartActivity extends BaseActivity<ActivityWpiTapCartBinding> implem
     private final NumberFormat currencyFormatter = NumberFormat.getCurrencyInstance();
 
     public static final String ARG_FAVOURITE_PRODUCT_ID = "arg_favourite";
+    public static final String ARG_FROM_SHORTCUT = "arg_from_shortcut";
 
     /**
      * The latest instance of the cart we've found.
@@ -83,6 +87,11 @@ public class CartActivity extends BaseActivity<ActivityWpiTapCartBinding> implem
         // product will already be in the cart, so don't add it again.
         if (savedInstanceState == null) {
             initialProductId = getIntent().getIntExtra(ARG_FAVOURITE_PRODUCT_ID, -1);
+
+            // Record use of the shortcut.
+            if (getIntent().getBooleanExtra(ARG_FROM_SHORTCUT, false)) {
+                ShortcutManagerCompat.reportShortcutUsed(this, FAVOURITE_PINNED_SHORTCUT);
+            }
         }
 
         viewModel = new ViewModelProvider(this, new CartViewModel.Factory(getApplication(), initialProductId)).get(CartViewModel.class);

--- a/app/src/main/java/be/ugent/zeus/hydra/wpi/tap/product/ProductFragment.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/wpi/tap/product/ProductFragment.java
@@ -129,9 +129,11 @@ public class ProductFragment extends Fragment {
     @Override
     public void onCreateOptionsMenu(@NonNull Menu menu, @NonNull MenuInflater inflater) {
         inflater.inflate(R.menu.menu_wpi_products, menu);
+        
+        // Set saved preference for stock stuff.
         MenuItem item = menu.findItem(R.id.action_filter_stock);
         SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(requireContext());
-        boolean show = preferences.getBoolean(PREF_SHOW_ONLY_IN_STOCK, true);
+        boolean show = preferences.getBoolean(PREF_SHOW_ONLY_IN_STOCK, false);
         item.setChecked(show);
         super.onCreateOptionsMenu(menu, inflater);
     }

--- a/app/src/main/java/be/ugent/zeus/hydra/wpi/tap/product/ProductFragment.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/wpi/tap/product/ProductFragment.java
@@ -27,14 +27,20 @@ import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.*;
+import android.widget.Toast;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.content.pm.ShortcutInfoCompat;
+import androidx.core.content.pm.ShortcutManagerCompat;
+import androidx.core.graphics.drawable.IconCompat;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.preference.PreferenceManager;
 import androidx.recyclerview.widget.RecyclerView;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 import be.ugent.zeus.hydra.R;
@@ -56,13 +62,20 @@ import static be.ugent.zeus.hydra.wpi.tap.product.ProductData.PREF_SHOW_ONLY_IN_
  */
 public class ProductFragment extends Fragment {
 
+    private static final String SAVED_FAVOURITE = "saved_favourite";
+    public static final String FAVOURITE_PINNED_SHORTCUT = "be.ugent.zeus.hydra.wpi.pinned_shortcut_favourite_tap";
+
     private static final String TAG = "ProductFragment";
     private ProductViewModel viewModel;
+    private int favouriteProductId = -1;
 
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setHasOptionsMenu(true);
+        if (savedInstanceState != null) {
+            favouriteProductId = savedInstanceState.getInt(SAVED_FAVOURITE, -1);
+        }
     }
 
     @Override
@@ -113,15 +126,21 @@ public class ProductFragment extends Fragment {
                 if (!product.isPresent()) {
                     // Oops.
                     fab.hide();
+                    requireActivity().invalidateOptionsMenu();
+                    favouriteProductId = -1;
+                    maybeUpdateShortcut();
                     return;
                 }
                 Product favourite = product.get();
+                favouriteProductId = favourite.getId();
                 fab.setOnClickListener(v -> {
                     Intent intent = new Intent(requireActivity(), CartActivity.class);
                     intent.putExtra(CartActivity.ARG_FAVOURITE_PRODUCT_ID, favourite.getId());
                     startActivityForResult(intent, ACTIVITY_DO_REFRESH);
                 });
                 fab.show();
+                requireActivity().invalidateOptionsMenu();
+                maybeUpdateShortcut();
             }
         });
     }
@@ -129,12 +148,17 @@ public class ProductFragment extends Fragment {
     @Override
     public void onCreateOptionsMenu(@NonNull Menu menu, @NonNull MenuInflater inflater) {
         inflater.inflate(R.menu.menu_wpi_products, menu);
-        
+
         // Set saved preference for stock stuff.
         MenuItem item = menu.findItem(R.id.action_filter_stock);
         SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(requireContext());
         boolean show = preferences.getBoolean(PREF_SHOW_ONLY_IN_STOCK, false);
         item.setChecked(show);
+
+        // Hide or show based on whether the user has a favourite item or not.
+        MenuItem pinItem = menu.findItem(R.id.action_pin_favourite);
+        pinItem.setVisible(favouriteProductId != -1);
+
         super.onCreateOptionsMenu(menu, inflater);
     }
 
@@ -148,6 +172,10 @@ public class ProductFragment extends Fragment {
                     .apply();
             item.setChecked(checked);
             viewModel.requestRefresh();
+            return true;
+        } else if (item.getItemId() == R.id.action_pin_favourite) {
+            createOrUpdatePinnedShortcut();
+            return true;
         }
 
         return super.onOptionsItemSelected(item);
@@ -158,5 +186,67 @@ public class ProductFragment extends Fragment {
         Snackbar.make(requireView(), getString(R.string.error_network), Snackbar.LENGTH_LONG)
                 .setAction(getString(R.string.action_again), v -> viewModel.requestRefresh())
                 .show();
+    }
+
+    private ShortcutInfoCompat createShortcutInfo() {
+        Intent intent = new Intent(Intent.ACTION_VIEW, null, requireActivity(), CartActivity.class);
+        intent.putExtra(CartActivity.ARG_FAVOURITE_PRODUCT_ID, favouriteProductId);
+        intent.putExtra(CartActivity.ARG_FROM_SHORTCUT, true);
+
+        return new ShortcutInfoCompat.Builder(requireContext(), FAVOURITE_PINNED_SHORTCUT)
+                .setShortLabel(getString(R.string.wpi_pin_description))
+                .setIcon(IconCompat.createWithResource(requireContext(), R.drawable.shortcut_tap_favourite))
+                .setIntent(intent)
+                .build();
+    }
+
+    private boolean maybeUpdateShortcut() {
+        boolean exists = ShortcutManagerCompat.getShortcuts(requireContext(), ShortcutManagerCompat.FLAG_MATCH_PINNED)
+                .stream().anyMatch(sic -> sic.getId().equals(FAVOURITE_PINNED_SHORTCUT));
+
+        if (!exists) {
+            return false; // Nothing do to here.
+        }
+
+        if (favouriteProductId == -1) {
+            List<String> ids = Collections.singletonList(FAVOURITE_PINNED_SHORTCUT);
+            ShortcutManagerCompat.disableShortcuts(requireContext(), ids, getString(R.string.wpi_pin_no_favourite));
+        } else {
+            ShortcutInfoCompat info = createShortcutInfo();
+            ShortcutManagerCompat.enableShortcuts(requireContext(), Collections.singletonList(info));
+        }
+
+        return true;
+    }
+
+    private void createOrUpdatePinnedShortcut() {
+        if (!ShortcutManagerCompat.isRequestPinShortcutSupported(requireContext())) {
+            Snackbar.make(requireView(), getString(R.string.wpi_pin_unsupported), Snackbar.LENGTH_LONG)
+                    .show();
+            return;
+        }
+
+        boolean updated = maybeUpdateShortcut();
+
+        if (updated) {
+            // We updated an existing shortcut, so nothing more to do here.
+            Toast.makeText(requireContext(), R.string.wpi_pin_updated, Toast.LENGTH_LONG).show();
+            return;
+        }
+
+        if (favouriteProductId == -1) {
+            // Don't create a shortcut for a favourite item that doesn't exist.
+            Toast.makeText(requireContext(), R.string.wpi_pin_no_favourite, Toast.LENGTH_LONG).show();
+            return;
+        }
+
+        ShortcutInfoCompat info = createShortcutInfo();
+        ShortcutManagerCompat.requestPinShortcut(requireContext(), info, null);
+    }
+
+    @Override
+    public void onSaveInstanceState(@NonNull Bundle outState) {
+        outState.putInt(SAVED_FAVOURITE, favouriteProductId);
+        super.onSaveInstanceState(outState);
     }
 }

--- a/app/src/main/res/drawable/shortcut_tap_favourite.xml
+++ b/app/src/main/res/drawable/shortcut_tap_favourite.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright (c) 2022 Niko Strijbol
+  ~ Copyright (c) 2022 The Hydra authors
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal
@@ -21,19 +21,15 @@
   ~ SOFTWARE.
   -->
 
-<menu xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
-    <item
-        android:id="@+id/action_filter_stock"
-        android:icon="@drawable/ic_login"
-        android:orderInCategory="50"
-        android:title="@string/wpi_product_filter"
-        app:showAsAction="never"
-        android:checkable="true" />
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
 
     <item
-        android:id="@+id/action_pin_favourite"
-        android:orderInCategory="50"
-        android:title="@string/wpi_pin_favourite"
-        app:showAsAction="never" />
-</menu>
+        android:bottom="2dp"
+        android:drawable="@drawable/shortcut_background"
+        android:left="2dp"
+        android:right="2dp"
+        android:top="2dp" />
+
+    <item android:drawable="@drawable/shortcut_tap_favourite_foreground" />
+
+</layer-list>

--- a/app/src/main/res/drawable/shortcut_tap_favourite_foreground.xml
+++ b/app/src/main/res/drawable/shortcut_tap_favourite_foreground.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright 2016 Google LLC
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="48"
+    android:viewportHeight="48">
+
+    <path
+        android:fillColor="@color/wpi_launcher_color"
+        android:pathData="M24,33.35l-1.45,-1.32C17.4,27.36 14,24.28 14,20.5 14,17.42 16.42,15 19.5,15c1.74,0 3.41,0.81 4.5,2.09C25.09,15.81 26.76,15 28.5,15 31.58,15 34,17.42 34,20.5c0,3.78 -3.4,6.86 -8.55,11.54L24,33.35z" />
+</vector>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -319,6 +319,11 @@
     <string name="wpi_product_description">Calories: %1$s • In stock: %2$d</string>
     <string name="wpi_product_na">n/a</string>
     <string name="wpi_product_filter">Only in stock</string>
+    <string name="wpi_pin_favourite">Shortcut for favourite</string>
+    <string name="wpi_pin_unsupported">Launcher does not support this</string>
+    <string name="wpi_pin_description">Favourite</string>
+    <string name="wpi_pin_no_favourite">You don\'t have a favourite</string>
+    <string name="wpi_pin_updated">Updated existing shortcut</string>
     <string name="wpi_user_description">Balance: %1$s • Orders: %2$s</string>
     <string name="wpi_tap_tab">Products</string>
     <string name="wpi_tab_tab">Transactions</string>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-  ~ Copyright (c) 2021 The Hydra authors
+  ~ Copyright (c) 2022 The Hydra authors
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal
@@ -90,6 +90,7 @@
         -->
     <color name="launcher_shortcut_background">@color/material_color_grey_100</color>
     <color name="hydra_launcher_color">@color/md_theme_light_primary</color>
+    <color name="wpi_launcher_color">@color/wpi_theme_light_primary</color>
 
     <!-- Zeus theme -->
     <color name="wpi_theme_light_primary">#984800</color>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -326,6 +326,11 @@
     <string name="wpi_product_description">Calorieën: %1$s • In voorraad: %2$d</string>
     <string name="wpi_product_na">n.v.t.</string>
     <string name="wpi_product_filter">Enkel in voorraad</string>
+    <string name="wpi_pin_favourite">Snelkoppeling voor dagschotel</string>
+    <string name="wpi_pin_unsupported">Startscherm ondersteunt dit niet</string>
+    <string name="wpi_pin_description">Dagschotel</string>
+    <string name="wpi_pin_no_favourite">U heeft geen dagschotel</string>
+    <string name="wpi_pin_updated">Bestaande snelkoppeling bijgewerkt</string>
     <string name="wpi_user_description">Saldo: %1$s • Bestellingen: %2$s</string>
     <string name="wpi_tap_tab">Producten</string>
     <string name="wpi_tab_tab">Transacties</string>


### PR DESCRIPTION
Allow pinning a shortcut to the homescreen, which opens the cart activity directly with the dagschotel preloaded. This should save at least two clicks when ordering dagschotels. It is basically a better version of a widget (since this is a shortcut, it needs no updates in the background).

This PR also shows all products by default, since the stock is not really kept up-to-date.