### PR TITLE
Fix null pointer exception

### DIFF
--- a/app/src/main/java/be/ugent/zeus/hydra/wpi/tap/cart/CartActivity.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/wpi/tap/cart/CartActivity.java
@@ -310,7 +310,12 @@ public class CartActivity extends BaseActivity<ActivityWpiTapCartBinding> implem
     }
 
     private void clearCart(boolean stopping) {
-        Cart newCart = this.viewModel.getLastCart().clear();
+        Cart newCart = this.viewModel.getLastCart();
+        if (newCart == null) {
+            // If closing too fast, this is still null.
+            return;
+        }
+        newCart = newCart.clear();
         saveCart(newCart, stopping);
     }
 


### PR DESCRIPTION
The user can press the button to clear the cart before the cart has
loaded, in which case there is no cart to clear, so: null pointer.