### PR TITLE
Add fallback for missing Play Store

### DIFF
--- a/app/src/main/java/be/ugent/zeus/hydra/MainActivity.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/MainActivity.java
@@ -22,6 +22,7 @@
 
 package be.ugent.zeus.hydra;
 
+import android.content.ActivityNotFoundException;
 import android.content.Intent;
 import android.content.pm.ShortcutManager;
 import android.content.res.Configuration;
@@ -46,6 +47,7 @@ import be.ugent.zeus.hydra.association.list.EventFragment;
 import be.ugent.zeus.hydra.common.reporting.Event;
 import be.ugent.zeus.hydra.common.reporting.Reporting;
 import be.ugent.zeus.hydra.common.ui.BaseActivity;
+import be.ugent.zeus.hydra.common.utils.NetworkUtils;
 import be.ugent.zeus.hydra.databinding.ActivityMainBinding;
 import be.ugent.zeus.hydra.feed.HomeFeedFragment;
 import be.ugent.zeus.hydra.info.InfoFragment;
@@ -365,10 +367,18 @@ public class MainActivity extends BaseActivity<ActivityMainBinding> implements N
             if (launchIntent != null) {
                 startActivity(launchIntent);
             } else {
+                Uri uforaUri = Uri.parse("https://play.google.com/store/apps/details?id=" + UFORA);
                 Intent intent = new Intent(Intent.ACTION_VIEW);
-                intent.setData(Uri.parse("https://play.google.com/store/apps/details?id=" + UFORA));
+                intent.setData(uforaUri);
                 intent.setPackage("com.android.vending");
-                startActivity(intent);
+                try {
+                    startActivity(intent);
+                } catch (ActivityNotFoundException e) {
+                    Log.e(TAG, "Could not find any app store...", e);
+                    // Open in a browser instead.
+                    NetworkUtils.maybeLaunchBrowser(this, uforaUri);
+                }
+                
             }
             return; // Don't do anything.
         }

--- a/app/src/main/java/be/ugent/zeus/hydra/common/utils/NetworkUtils.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/common/utils/NetworkUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 The Hydra authors
+ * Copyright (c) 2022 The Hydra authors
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -55,9 +55,7 @@ public class NetworkUtils {
         }
 
         if (Build.VERSION.SDK_INT < 29) {
-            //noinspection deprecation
             NetworkInfo networkInfo = manager.getActiveNetworkInfo();
-            //noinspection deprecation
             return (networkInfo != null && networkInfo.isConnected());
         } else {
             Network network = manager.getActiveNetwork();
@@ -89,11 +87,22 @@ public class NetworkUtils {
      * Opens a browser for the given url.
      *
      * @param context The context to launch from.
+     * @param uri     The uri to launch.
+     * @see #maybeLaunchIntent(Context, Intent)
+     */
+    public static void maybeLaunchBrowser(Context context, Uri uri) {
+        maybeLaunchIntent(context, new Intent(Intent.ACTION_VIEW, uri));
+    }
+
+    /**
+     * Opens a browser for the given url.
+     *
+     * @param context The context to launch from.
      * @param url     The url to launch.
      * @see #maybeLaunchIntent(Context, Intent)
      */
     public static void maybeLaunchBrowser(Context context, String url) {
-        maybeLaunchIntent(context, new Intent(Intent.ACTION_VIEW, Uri.parse(url)));
+        maybeLaunchBrowser(context, Uri.parse(url));
     }
 
     /**

--- a/flake.lock
+++ b/flake.lock
@@ -11,11 +11,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1659039907,
-        "narHash": "sha256-6KjBUGdXmvuZwQ8I3Qo6dBT3lUZUKMl9dKa3sfIMqgA=",
+        "lastModified": 1660076723,
+        "narHash": "sha256-HfNbeH5AWqNfm5jYiGb7grFn7SG8KO5dT3zK0xlFPUU=",
         "owner": "tadfisher",
         "repo": "android-nixpkgs",
-        "rev": "998b1b65c3d62d3449e5f1828cc278d1b996ffe4",
+        "rev": "0ac0be808f25578f409f3dca0049359c9f91929b",
         "type": "github"
       },
       "original": {
@@ -75,11 +75,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1656928814,
-        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
         "type": "github"
       },
       "original": {
@@ -90,11 +90,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1659077768,
-        "narHash": "sha256-P0XIHBVty6WIuIrk2DZNvLcYev9956y1prT4zL212H8=",
+        "lastModified": 1659981942,
+        "narHash": "sha256-uCFiP/B/NXOWzhN6TKfMbSxtVMk1bVnCrnJRjCF6RmU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2a93ea177c3d7700b934bf95adfe00c435f696b8",
+        "rev": "39d7f929fbcb1446ad7aa7441b04fb30625a4190",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -47,6 +47,7 @@
           sources-android-32
           emulator
           system-images-android-21-google-apis-x86
+          system-images-android-21-default-x86
         ]);
       in
       {
@@ -65,6 +66,10 @@
               {
                 name = "ANDROID_SDK_ROOT";
                 eval = "${android-sdk}/share/android-sdk";
+              }
+              {
+                name = "GRADLE_OPTS";
+                eval = "-Dorg.gradle.project.android.aapt2FromMavenOverride=${android-sdk}/share/android-sdk/build-tools/32.0.0/aapt2";
               }
             ];
             commands = [


### PR DESCRIPTION
If there is no Play Store on the device, open the Ufora app in the browser instead. I couldn't find a generic "app store" intent, and even if it did exist, the Ufora app is only available from the Play Store.

Fix #628 