### PR TITLE
Include R8 rules for RxJava 1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -185,6 +185,7 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-common-java8:2.5.1"
     implementation "androidx.viewpager2:viewpager2:1.0.0"
     implementation 'androidx.room:room-runtime:2.4.3'
+    implementation 'com.artemzin.rxjava:proguard-rules:1.3.3.0'
     annotationProcessor 'androidx.room:room-compiler:2.4.3'
     implementation 'com.squareup.okhttp3:okhttp:4.10.0'
     implementation 'com.squareup.moshi:moshi:1.13.0'


### PR DESCRIPTION
This is unfortunately used by the mjpeg library.

Fixes #627.