### PR TITLE
Fix crash on older devices

### DIFF
--- a/app/src/main/java/be/ugent/zeus/hydra/resto/RestoMenu.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/resto/RestoMenu.java
@@ -31,6 +31,7 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 /**
  * Represents a menu for a single day.
@@ -117,7 +118,7 @@ public final class RestoMenu implements Parcelable {
         }
         final String suffix = priceBig;
         
-        return finalSoups.stream().map(s -> s.withPrice(s.price() + " / " + suffix)).toList();
+        return finalSoups.stream().map(s -> s.withPrice(s.price() + " / " + suffix)).collect(Collectors.toList());
     }
 
     /**


### PR DESCRIPTION
Fix a crash on older devices.

For those with access: https://console.firebase.google.com/project/hydra-142516/crashlytics/app/android:be.ugent.zeus.hydra/issues/183b608e3e634aceb237ea4bc002fc0f