### PR TITLE
Open external links from the web view in the browser

### DIFF
--- a/app/src/main/java/be/ugent/zeus/hydra/common/ui/WebViewActivity.java
+++ b/app/src/main/java/be/ugent/zeus/hydra/common/ui/WebViewActivity.java
@@ -24,6 +24,8 @@ package be.ugent.zeus.hydra.common.ui;
 
 import android.annotation.SuppressLint;
 import android.content.Intent;
+import android.net.Uri;
+import android.content.ActivityNotFoundException;
 import android.os.Bundle;
 import android.view.View;
 import android.webkit.WebView;
@@ -63,6 +65,19 @@ public class WebViewActivity extends BaseActivity<ActivityWebviewBinding> {
     }
 
     private static class ProgressClient extends WebViewClient {
+        @Override
+        public boolean shouldOverrideUrlLoading(WebView view, String url) {
+            if (url.startsWith("http://") || url.startsWith("https://")) {
+                try {
+                    view.getContext().startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(url)));
+                } catch (ActivityNotFoundException e) {
+                    // no app available to open the link
+                }
+                return true;
+            }
+            return false;
+        }
+
         private final ProgressBar progressBar;
 
         ProgressClient(ProgressBar progressBar) {


### PR DESCRIPTION
This adds a `shouldOverrideUrlLoading` override to the web view so that http and https links open in the system browser instead of loading inside the view.

The view has no address bar or navigation controls, so a link tapped today loads in place and can leave the user far from the page they opened. With this change normal web links go to the browser, other schemes keep the default behavior, and a missing handler is caught so it cannot crash the view.

Closes #1176.